### PR TITLE
fix: pnpm/action-setupをcorepackで置き換え

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,19 +11,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - run: corepack enable
       - name: Setup Nodejs v20
         uses: actions/setup-node@v4
-
-      - uses: pnpm/action-setup@v2
         with:
-          version: 9
-
-      - name: Cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/install/cache
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: ${{ runner.os }}-pnpm-
+          node-version: 20
+          cache: "pnpm"
 
       - name: Install packages
         run: pnpm i --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
   "version": "0.0.1",
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "packageManager": "pnpm@9.3.0"
 }


### PR DESCRIPTION
close #71 

## 作業内容
- pnpm/action-setupをやめて`corepack`を有効化した