### PR TITLE
refactor: モデルのゲッター/セッターを関数に置き換え

### DIFF
--- a/packages/kcms/src/entry/adaptor/dummyRepository.ts
+++ b/packages/kcms/src/entry/adaptor/dummyRepository.ts
@@ -14,7 +14,7 @@ export class DummyRepository implements EntryRepository {
   }
 
   async findByTeamName(name: string): Promise<Option.Option<Entry>> {
-    const entry = this.data.find((e) => e.teamName === name);
+    const entry = this.data.find((e) => e.getTeamName() === name);
     if (entry === undefined) {
       return Option.none();
     }
@@ -22,7 +22,7 @@ export class DummyRepository implements EntryRepository {
   }
 
   async findByID(id: string): Promise<Option.Option<Entry>> {
-    const entry = this.data.find((e) => e.id === id);
+    const entry = this.data.find((e) => e.getId() === id);
     if (entry === undefined) {
       return Option.none();
     }
@@ -34,7 +34,7 @@ export class DummyRepository implements EntryRepository {
   }
 
   async delete(id: string): Promise<Option.Option<Error>> {
-    this.data = this.data.filter((e) => e.id !== id);
+    this.data = this.data.filter((e) => e.getId() !== id);
     return Option.none();
   }
 

--- a/packages/kcms/src/entry/adaptor/json.ts
+++ b/packages/kcms/src/entry/adaptor/json.ts
@@ -1,7 +1,7 @@
-import {EntryRepository} from '../repository.js';
-import {Option, Result} from '@mikuroxina/mini-fn';
-import {Entry, EntryCategory, EntryID} from '../entry.js';
-import {readFile, writeFile} from 'node:fs/promises';
+import { EntryRepository } from '../repository.js';
+import { Option, Result } from '@mikuroxina/mini-fn';
+import { Entry, EntryCategory, EntryID } from '../entry.js';
+import { readFile, writeFile } from 'node:fs/promises';
 
 interface JSONData {
   entry: Array<EntryJSON>;

--- a/packages/kcms/src/entry/adaptor/json.ts
+++ b/packages/kcms/src/entry/adaptor/json.ts
@@ -1,7 +1,7 @@
-import { EntryRepository } from '../repository.js';
-import { Option, Result } from '@mikuroxina/mini-fn';
-import { Entry, EntryCategory, EntryID } from '../entry.js';
-import { readFile, writeFile } from 'node:fs/promises';
+import {EntryRepository} from '../repository.js';
+import {Option, Result} from '@mikuroxina/mini-fn';
+import {Entry, EntryCategory, EntryID} from '../entry.js';
+import {readFile, writeFile} from 'node:fs/promises';
 
 interface JSONData {
   entry: Array<EntryJSON>;
@@ -38,7 +38,7 @@ export class JSONEntryRepository implements EntryRepository {
   }
 
   async findByTeamName(name: string): Promise<Option.Option<Entry>> {
-    const entry = this.data.find((e) => e.teamName === name);
+    const entry = this.data.find((e) => e.getTeamName() === name);
     if (entry === undefined) {
       return Option.none();
     }
@@ -46,7 +46,7 @@ export class JSONEntryRepository implements EntryRepository {
   }
 
   async findByID(id: string): Promise<Option.Option<Entry>> {
-    const entry = this.data.find((e) => e.id === id);
+    const entry = this.data.find((e) => e.getId() === id);
     if (entry === undefined) {
       return Option.none();
     }
@@ -58,7 +58,7 @@ export class JSONEntryRepository implements EntryRepository {
   }
 
   async delete(id: string): Promise<Option.Option<Error>> {
-    this.data = this.data.filter((e) => e.id !== id);
+    this.data = this.data.filter((e) => e.getId() !== id);
     await this.save();
     return Option.none();
   }
@@ -73,14 +73,12 @@ export class JSONEntryRepository implements EntryRepository {
 
   private static async load(): Promise<JSONData> {
     const data = await readFile('./data.json', 'utf-8');
-    const parsed = JSON.parse(data) as JSONData;
-    parsed.entry = parsed.entry.map((e) => JSONEntryRepository.jsonToEntry(e));
-    return parsed;
+    return JSON.parse(data) as JSONData;
   }
 
   private isExists(entry: Entry): boolean {
     for (const v of this.data) {
-      if (v.teamName === entry.teamName || v.id === entry.id) {
+      if (v.getTeamName === entry.getTeamName || v.getId === entry.getId) {
         console.error('Entry already exists');
         return true;
       }
@@ -90,11 +88,11 @@ export class JSONEntryRepository implements EntryRepository {
 
   private static entryToJSON(entry: Entry): EntryJSON {
     return {
-      id: entry.id,
-      teamName: entry.teamName,
-      members: entry.members,
-      isMultiWalk: entry.isMultiWalk,
-      category: entry.category,
+      id: entry.getId(),
+      teamName: entry.getTeamName(),
+      members: entry.getMembers(),
+      isMultiWalk: entry.getIsMultiWalk(),
+      category: entry.getCategory(),
     };
   }
 

--- a/packages/kcms/src/entry/controller.ts
+++ b/packages/kcms/src/entry/controller.ts
@@ -38,7 +38,14 @@ export class Controller {
       return Result.err(res[1]);
     }
 
-    return Result.ok(res[1]);
+    const unwrapped = Result.unwrap(res);
+    return Result.ok({
+      id: unwrapped.getId(),
+        teamName: unwrapped.getTeamName(),
+        members: unwrapped.getMembers(),
+        isMultiWalk: unwrapped.getIsMultiWalk(),
+        category: unwrapped.getCategory(),
+    });
   }
 
   async get(): Promise<Result.Result<Error, baseEntry[]>> {

--- a/packages/kcms/src/entry/controller.ts
+++ b/packages/kcms/src/entry/controller.ts
@@ -41,10 +41,10 @@ export class Controller {
     const unwrapped = Result.unwrap(res);
     return Result.ok({
       id: unwrapped.getId(),
-        teamName: unwrapped.getTeamName(),
-        members: unwrapped.getMembers(),
-        isMultiWalk: unwrapped.getIsMultiWalk(),
-        category: unwrapped.getCategory(),
+      teamName: unwrapped.getTeamName(),
+      members: unwrapped.getMembers(),
+      isMultiWalk: unwrapped.getIsMultiWalk(),
+      category: unwrapped.getCategory(),
     });
   }
 

--- a/packages/kcms/src/entry/entry.test.ts
+++ b/packages/kcms/src/entry/entry.test.ts
@@ -11,10 +11,10 @@ describe('正しくインスタンスを生成できる', () => {
       category: 'Open',
     });
 
-    expect(actual.id).toBe('123');
-    expect(actual.teamName).toBe('チーム1');
-    expect(actual.members).toEqual(['山田太郎', 'テスト大介']);
-    expect(actual.isMultiWalk).toBe(false);
-    expect(actual.category).toBe('Open');
+    expect(actual.getId()).toBe('123');
+    expect(actual.getTeamName()).toBe('チーム1');
+    expect(actual.getMembers()).toEqual(['山田太郎', 'テスト大介']);
+    expect(actual.getIsMultiWalk()).toBe(false);
+    expect(actual.getCategory()).toBe('Open');
   });
 });

--- a/packages/kcms/src/entry/entry.ts
+++ b/packages/kcms/src/entry/entry.ts
@@ -14,11 +14,11 @@ export interface EntryCreateArgs {
 }
 
 export class Entry {
-  private readonly _id: EntryID;
-  private readonly _teamName: string;
-  private readonly _members: Array<string>;
-  private readonly _isMultiWalk: boolean;
-  private readonly _category: EntryCategory;
+  private readonly id: EntryID;
+  private readonly teamName: string;
+  private readonly members: Array<string>;
+  private readonly isMultiWalk: boolean;
+  private readonly category: EntryCategory;
 
   private constructor(
     id: EntryID,
@@ -27,31 +27,31 @@ export class Entry {
     _isMultiWalk: boolean,
     category: EntryCategory
   ) {
-    this._id = id;
-    this._teamName = teamName;
-    this._members = _members;
-    this._isMultiWalk = _isMultiWalk;
-    this._category = category;
+    this.id = id;
+    this.teamName = teamName;
+    this.members = _members;
+    this.isMultiWalk = _isMultiWalk;
+    this.category = category;
   }
 
-  get id(): EntryID {
-    return this._id;
+  getId(): EntryID {
+    return this.id;
   }
 
-  get teamName(): string {
-    return this._teamName;
+  getTeamName(): string {
+    return this.teamName;
   }
 
-  get members(): Array<string> {
-    return this._members;
+  getMembers(): Array<string> {
+    return this.members;
   }
 
-  get isMultiWalk(): boolean {
-    return this._isMultiWalk;
+  getIsMultiWalk(): boolean {
+    return this.isMultiWalk;
   }
 
-  get category(): EntryCategory {
-    return this._category;
+  getCategory(): EntryCategory {
+    return this.category;
   }
 
   public static new(arg: EntryCreateArgs): Entry {

--- a/packages/kcms/src/entry/service/entry.test.ts
+++ b/packages/kcms/src/entry/service/entry.test.ts
@@ -1,83 +1,116 @@
-import { afterEach, describe, expect, it } from 'vitest';
-import { DummyRepository } from '../adaptor/dummyRepository.js';
-import { Entry, EntryID } from '../entry.js';
-import { Result } from '@mikuroxina/mini-fn';
-import { EntryService } from './entry.js';
-import { TestEntryData } from '../../testData/entry.js';
-import { SnowflakeIDGenerator } from '../../id/main.js';
+import {afterEach, describe, expect, it} from 'vitest';
+import {DummyRepository} from '../adaptor/dummyRepository.js';
+import {Entry, EntryID} from '../entry.js';
+import {Result} from '@mikuroxina/mini-fn';
+import {EntryService} from './entry.js';
+import {TestEntryData} from '../../testData/entry.js';
+import {SnowflakeIDGenerator} from '../../id/main.js';
 
 describe('entryService', () => {
-  const repository = new DummyRepository();
-  const service = new EntryService(
-    repository,
-    new SnowflakeIDGenerator(1, () => BigInt(new Date().getTime()))
-  );
+    const repository = new DummyRepository();
+    const service = new EntryService(
+        repository,
+        new SnowflakeIDGenerator(1, () => BigInt(new Date().getTime()))
+    );
 
-  afterEach(() => {
-    repository.reset();
-  });
-
-  it('エントリーできる', async () => {
-    const actual = await service.create(TestEntryData['ElementaryMultiWalk']);
-
-    expect(Result.isOk(actual)).toBe(true);
-    if (Result.isErr(actual)) {
-      return;
-    }
-
-    expect(actual[1].members).toStrictEqual(['TestTaro1']);
-    expect(actual[1].teamName).toBe('TestTeam1');
-    expect(actual[1].isMultiWalk).toBe(true);
-    expect(actual[1].category).toBe('Elementary');
-  });
-
-  it('チーム名が重複するときはエラー終了する', async () => {
-    await service.create(TestEntryData['ElementaryMultiWalk']);
-    const result = await service.create(TestEntryData['ElementaryMultiWalkExists']);
-
-    expect(Result.isErr(result)).toBe(true);
-    expect(result[1]).toStrictEqual(new Error('teamName Exists'));
-  });
-
-  it('オープン部門のメンバーは1人のみ', async () => {
-    const entry = Entry.new({
-      id: '123' as EntryID,
-      teamName: 'team1',
-      members: ['山田四十郎', '山田太郎'],
-      isMultiWalk: true,
-      category: 'Open',
+    afterEach(() => {
+        repository.reset();
     });
-    const actual = await service.create(entry);
 
-    expect(Result.isErr(actual)).toBe(true);
-    expect(actual[1]).toStrictEqual(new Error('too many members'));
-  });
+    it('エントリーできる', async () => {
+        const data = TestEntryData['ElementaryMultiWalk'];
+        const actual = await service.create({
+            teamName: data.getTeamName(),
+            members: data.getMembers(),
+            isMultiWalk: data.getIsMultiWalk(),
+            category: data.getCategory(),
+        });
 
-  it('小学生部門のメンバーは1または2人', async () => {
-    const entry = Entry.new({
-      id: '123' as EntryID,
-      teamName: 'team1',
-      members: ['山田四十郎', '山田太郎', '山田次郎'],
-      isMultiWalk: true,
-      category: 'Elementary',
+        expect(Result.isOk(actual)).toBe(true);
+        if (Result.isErr(actual)) {
+            return;
+        }
+
+        expect(actual[1].getMembers()).toStrictEqual(['TestTaro1']);
+        expect(actual[1].getTeamName()).toBe('TestTeam1');
+        expect(actual[1].getIsMultiWalk()).toBe(true);
+        expect(actual[1].getCategory()).toBe('Elementary');
     });
-    const actual = await service.create(entry);
 
-    expect(Result.isErr(actual)).toBe(true);
-    expect(actual[1]).toStrictEqual(new Error('too many members'));
-  });
+    it('チーム名が重複するときはエラー終了する', async () => {
+        const data = TestEntryData['ElementaryMultiWalk'];
+        const existsData = TestEntryData['ElementaryMultiWalkExists']
+        await service.create({
+            teamName: data.getTeamName(),
+            members: data.getMembers(),
+            isMultiWalk: data.getIsMultiWalk(),
+            category: data.getCategory(),
+        });
+        const result = await service.create({
+            teamName: existsData.getTeamName(),
+            members: existsData.getMembers(),
+            isMultiWalk: existsData.getIsMultiWalk(),
+            category: existsData.getCategory()
+        });
 
-  it('メンバーが居ないチームは作れない', async () => {
-    const entry = Entry.new({
-      id: '123' as EntryID,
-      teamName: 'team1',
-      members: [],
-      isMultiWalk: true,
-      category: 'Elementary',
+        expect(Result.isErr(result)).toBe(true);
+        expect(result[1]).toStrictEqual(new Error('teamName Exists'));
     });
-    const actual = await service.create(entry);
 
-    expect(Result.isErr(actual)).toBe(true);
-    expect(actual[1]).toStrictEqual(new Error('no member'));
-  });
+    it('オープン部門のメンバーは1人のみ', async () => {
+        const entry = Entry.new({
+            id: '123' as EntryID,
+            teamName: 'team1',
+            members: ['山田四十郎', '山田太郎'],
+            isMultiWalk: true,
+            category: 'Open',
+        });
+        const actual = await service.create({
+            teamName: entry.getTeamName(),
+            members: entry.getMembers(),
+            isMultiWalk: entry.getIsMultiWalk(),
+            category: entry.getCategory(),
+        });
+
+        expect(Result.isErr(actual)).toBe(true);
+        expect(actual[1]).toStrictEqual(new Error('too many members'));
+    });
+
+    it('小学生部門のメンバーは1または2人', async () => {
+        const entry = Entry.new({
+            id: '123' as EntryID,
+            teamName: 'team1',
+            members: ['山田四十郎', '山田太郎', '山田次郎'],
+            isMultiWalk: true,
+            category: 'Elementary',
+        });
+        const actual = await service.create({
+            teamName: entry.getTeamName(),
+            members: entry.getMembers(),
+            isMultiWalk: entry.getIsMultiWalk(),
+            category: entry.getCategory(),
+        });
+
+        expect(Result.isErr(actual)).toBe(true);
+        expect(actual[1]).toStrictEqual(new Error('too many members'));
+    });
+
+    it('メンバーが居ないチームは作れない', async () => {
+        const entry = Entry.new({
+            id: '123' as EntryID,
+            teamName: 'team1',
+            members: [],
+            isMultiWalk: true,
+            category: 'Elementary',
+        });
+        const actual = await service.create({
+            teamName: entry.getTeamName(),
+            members: entry.getMembers(),
+            isMultiWalk: entry.getIsMultiWalk(),
+            category: entry.getCategory(),
+        });
+
+        expect(Result.isErr(actual)).toBe(true);
+        expect(actual[1]).toStrictEqual(new Error('no member'));
+    });
 });

--- a/packages/kcms/src/entry/service/entry.test.ts
+++ b/packages/kcms/src/entry/service/entry.test.ts
@@ -1,116 +1,116 @@
-import {afterEach, describe, expect, it} from 'vitest';
-import {DummyRepository} from '../adaptor/dummyRepository.js';
-import {Entry, EntryID} from '../entry.js';
-import {Result} from '@mikuroxina/mini-fn';
-import {EntryService} from './entry.js';
-import {TestEntryData} from '../../testData/entry.js';
-import {SnowflakeIDGenerator} from '../../id/main.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DummyRepository } from '../adaptor/dummyRepository.js';
+import { Entry, EntryID } from '../entry.js';
+import { Result } from '@mikuroxina/mini-fn';
+import { EntryService } from './entry.js';
+import { TestEntryData } from '../../testData/entry.js';
+import { SnowflakeIDGenerator } from '../../id/main.js';
 
 describe('entryService', () => {
-    const repository = new DummyRepository();
-    const service = new EntryService(
-        repository,
-        new SnowflakeIDGenerator(1, () => BigInt(new Date().getTime()))
-    );
+  const repository = new DummyRepository();
+  const service = new EntryService(
+    repository,
+    new SnowflakeIDGenerator(1, () => BigInt(new Date().getTime()))
+  );
 
-    afterEach(() => {
-        repository.reset();
+  afterEach(() => {
+    repository.reset();
+  });
+
+  it('エントリーできる', async () => {
+    const data = TestEntryData['ElementaryMultiWalk'];
+    const actual = await service.create({
+      teamName: data.getTeamName(),
+      members: data.getMembers(),
+      isMultiWalk: data.getIsMultiWalk(),
+      category: data.getCategory(),
     });
 
-    it('エントリーできる', async () => {
-        const data = TestEntryData['ElementaryMultiWalk'];
-        const actual = await service.create({
-            teamName: data.getTeamName(),
-            members: data.getMembers(),
-            isMultiWalk: data.getIsMultiWalk(),
-            category: data.getCategory(),
-        });
+    expect(Result.isOk(actual)).toBe(true);
+    if (Result.isErr(actual)) {
+      return;
+    }
 
-        expect(Result.isOk(actual)).toBe(true);
-        if (Result.isErr(actual)) {
-            return;
-        }
+    expect(actual[1].getMembers()).toStrictEqual(['TestTaro1']);
+    expect(actual[1].getTeamName()).toBe('TestTeam1');
+    expect(actual[1].getIsMultiWalk()).toBe(true);
+    expect(actual[1].getCategory()).toBe('Elementary');
+  });
 
-        expect(actual[1].getMembers()).toStrictEqual(['TestTaro1']);
-        expect(actual[1].getTeamName()).toBe('TestTeam1');
-        expect(actual[1].getIsMultiWalk()).toBe(true);
-        expect(actual[1].getCategory()).toBe('Elementary');
+  it('チーム名が重複するときはエラー終了する', async () => {
+    const data = TestEntryData['ElementaryMultiWalk'];
+    const existsData = TestEntryData['ElementaryMultiWalkExists'];
+    await service.create({
+      teamName: data.getTeamName(),
+      members: data.getMembers(),
+      isMultiWalk: data.getIsMultiWalk(),
+      category: data.getCategory(),
+    });
+    const result = await service.create({
+      teamName: existsData.getTeamName(),
+      members: existsData.getMembers(),
+      isMultiWalk: existsData.getIsMultiWalk(),
+      category: existsData.getCategory(),
     });
 
-    it('チーム名が重複するときはエラー終了する', async () => {
-        const data = TestEntryData['ElementaryMultiWalk'];
-        const existsData = TestEntryData['ElementaryMultiWalkExists']
-        await service.create({
-            teamName: data.getTeamName(),
-            members: data.getMembers(),
-            isMultiWalk: data.getIsMultiWalk(),
-            category: data.getCategory(),
-        });
-        const result = await service.create({
-            teamName: existsData.getTeamName(),
-            members: existsData.getMembers(),
-            isMultiWalk: existsData.getIsMultiWalk(),
-            category: existsData.getCategory()
-        });
+    expect(Result.isErr(result)).toBe(true);
+    expect(result[1]).toStrictEqual(new Error('teamName Exists'));
+  });
 
-        expect(Result.isErr(result)).toBe(true);
-        expect(result[1]).toStrictEqual(new Error('teamName Exists'));
+  it('オープン部門のメンバーは1人のみ', async () => {
+    const entry = Entry.new({
+      id: '123' as EntryID,
+      teamName: 'team1',
+      members: ['山田四十郎', '山田太郎'],
+      isMultiWalk: true,
+      category: 'Open',
+    });
+    const actual = await service.create({
+      teamName: entry.getTeamName(),
+      members: entry.getMembers(),
+      isMultiWalk: entry.getIsMultiWalk(),
+      category: entry.getCategory(),
     });
 
-    it('オープン部門のメンバーは1人のみ', async () => {
-        const entry = Entry.new({
-            id: '123' as EntryID,
-            teamName: 'team1',
-            members: ['山田四十郎', '山田太郎'],
-            isMultiWalk: true,
-            category: 'Open',
-        });
-        const actual = await service.create({
-            teamName: entry.getTeamName(),
-            members: entry.getMembers(),
-            isMultiWalk: entry.getIsMultiWalk(),
-            category: entry.getCategory(),
-        });
+    expect(Result.isErr(actual)).toBe(true);
+    expect(actual[1]).toStrictEqual(new Error('too many members'));
+  });
 
-        expect(Result.isErr(actual)).toBe(true);
-        expect(actual[1]).toStrictEqual(new Error('too many members'));
+  it('小学生部門のメンバーは1または2人', async () => {
+    const entry = Entry.new({
+      id: '123' as EntryID,
+      teamName: 'team1',
+      members: ['山田四十郎', '山田太郎', '山田次郎'],
+      isMultiWalk: true,
+      category: 'Elementary',
+    });
+    const actual = await service.create({
+      teamName: entry.getTeamName(),
+      members: entry.getMembers(),
+      isMultiWalk: entry.getIsMultiWalk(),
+      category: entry.getCategory(),
     });
 
-    it('小学生部門のメンバーは1または2人', async () => {
-        const entry = Entry.new({
-            id: '123' as EntryID,
-            teamName: 'team1',
-            members: ['山田四十郎', '山田太郎', '山田次郎'],
-            isMultiWalk: true,
-            category: 'Elementary',
-        });
-        const actual = await service.create({
-            teamName: entry.getTeamName(),
-            members: entry.getMembers(),
-            isMultiWalk: entry.getIsMultiWalk(),
-            category: entry.getCategory(),
-        });
+    expect(Result.isErr(actual)).toBe(true);
+    expect(actual[1]).toStrictEqual(new Error('too many members'));
+  });
 
-        expect(Result.isErr(actual)).toBe(true);
-        expect(actual[1]).toStrictEqual(new Error('too many members'));
+  it('メンバーが居ないチームは作れない', async () => {
+    const entry = Entry.new({
+      id: '123' as EntryID,
+      teamName: 'team1',
+      members: [],
+      isMultiWalk: true,
+      category: 'Elementary',
+    });
+    const actual = await service.create({
+      teamName: entry.getTeamName(),
+      members: entry.getMembers(),
+      isMultiWalk: entry.getIsMultiWalk(),
+      category: entry.getCategory(),
     });
 
-    it('メンバーが居ないチームは作れない', async () => {
-        const entry = Entry.new({
-            id: '123' as EntryID,
-            teamName: 'team1',
-            members: [],
-            isMultiWalk: true,
-            category: 'Elementary',
-        });
-        const actual = await service.create({
-            teamName: entry.getTeamName(),
-            members: entry.getMembers(),
-            isMultiWalk: entry.getIsMultiWalk(),
-            category: entry.getCategory(),
-        });
-
-        expect(Result.isErr(actual)).toBe(true);
-        expect(actual[1]).toStrictEqual(new Error('no member'));
-    });
+    expect(Result.isErr(actual)).toBe(true);
+    expect(actual[1]).toStrictEqual(new Error('no member'));
+  });
 });

--- a/packages/kcms/src/entry/service/get.test.ts
+++ b/packages/kcms/src/entry/service/get.test.ts
@@ -29,13 +29,13 @@ describe('getEntryService', () => {
   });
 
   it('チーム名で取得できる', async () => {
-    const actual = await service.findByTeamName(testEntryData[0].teamName);
+    const actual = await service.findByTeamName(testEntryData[0].getTeamName());
     expect(Result.isOk(actual)).toBe(true);
     expect(actual[1]).toStrictEqual(EntryDTO.fromDomain(testEntryData[0]));
   });
 
   it('チームIDで取得できる', async () => {
-    const actual = await service.findByID(testEntryData[0].id);
+    const actual = await service.findByID(testEntryData[0].getId());
     expect(Result.isOk(actual)).toBe(true);
     expect(actual[1]).toStrictEqual(EntryDTO.fromDomain(testEntryData[0]));
   });

--- a/packages/kcms/src/entry/service/get.ts
+++ b/packages/kcms/src/entry/service/get.ts
@@ -61,7 +61,13 @@ export class EntryDTO {
   }
 
   public static fromDomain(d: Entry): EntryDTO {
-    return new EntryDTO(d.getId(), d.getTeamName(), d.getMembers(), d.getIsMultiWalk(), d.getCategory());
+    return new EntryDTO(
+      d.getId(),
+      d.getTeamName(),
+      d.getMembers(),
+      d.getIsMultiWalk(),
+      d.getCategory()
+    );
   }
 
   public toToDomain(): Entry {

--- a/packages/kcms/src/entry/service/get.ts
+++ b/packages/kcms/src/entry/service/get.ts
@@ -61,7 +61,7 @@ export class EntryDTO {
   }
 
   public static fromDomain(d: Entry): EntryDTO {
-    return new EntryDTO(d.id, d.teamName, d.members, d.isMultiWalk, d.category);
+    return new EntryDTO(d.getId(), d.getTeamName(), d.getMembers(), d.getIsMultiWalk(), d.getCategory());
   }
 
   public toToDomain(): Entry {

--- a/packages/kcms/src/match/adaptor/dummyRepository.ts
+++ b/packages/kcms/src/match/adaptor/dummyRepository.ts
@@ -20,7 +20,7 @@ export class DummyMatchRepository implements MatchRepository {
   }
 
   public async findByID(id: string): Promise<Option.Option<Match>> {
-    const match = this.data.find((m) => m.id === id);
+    const match = this.data.find((m) => m.getId() === id);
     if (!match) {
       return Option.none();
     }
@@ -28,7 +28,7 @@ export class DummyMatchRepository implements MatchRepository {
   }
 
   public async findByType(type: string): Promise<Option.Option<Match[]>> {
-    const match = this.data.filter((m) => m.matchType === type);
+    const match = this.data.filter((m) => m.getMatchType() === type);
     if (!match) {
       return Option.none();
     }
@@ -36,7 +36,7 @@ export class DummyMatchRepository implements MatchRepository {
   }
 
   public async update(match: Match): Promise<Result.Result<Error, Match>> {
-    const i = this.data.findIndex((m) => m.id === match.id);
+    const i = this.data.findIndex((m) => m.getId() === match.getId());
     this.data[i] = match;
     return Result.ok(match);
   }

--- a/packages/kcms/src/match/adaptor/json.ts
+++ b/packages/kcms/src/match/adaptor/json.ts
@@ -62,7 +62,7 @@ export class JSONMatchRepository implements MatchRepository {
   }
 
   public async findByID(id: string): Promise<Option.Option<Match>> {
-    const match = this.data.find((m) => m.id === id);
+    const match = this.data.find((m) => m.getId() === id);
     if (!match) {
       return Option.none();
     }
@@ -71,7 +71,7 @@ export class JSONMatchRepository implements MatchRepository {
   }
 
   public async findByType(type: string): Promise<Option.Option<Match[]>> {
-    const match = this.data.filter((m) => m.matchType === type);
+    const match = this.data.filter((m) => m.getMatchType() === type);
     if (!match) {
       return Option.none();
     }
@@ -83,7 +83,7 @@ export class JSONMatchRepository implements MatchRepository {
   }
 
   public async update(match: Match): Promise<Result.Result<Error, Match>> {
-    const i = this.data.findIndex((m) => m.id === match.id);
+    const i = this.data.findIndex((m) => m.getId === match.getId);
     this.data[i] = match;
 
     await this.save();
@@ -121,14 +121,14 @@ export class JSONMatchRepository implements MatchRepository {
     };
 
     return {
-      id: match.id,
+      id: match.getId(),
       teams: {
-        left: covertToEntryJSON(match.teams.left),
-        right: covertToEntryJSON(match.teams.right),
+        left: covertToEntryJSON(match.getTeams().left),
+        right: covertToEntryJSON(match.getTeams().right),
       },
-      matchType: match.matchType,
-      courseIndex: match.courseIndex,
-      results: match.results,
+      matchType: match.getMatchType(),
+      courseIndex: match.getCourseIndex(),
+      results: match.getResults(),
     };
   }
 

--- a/packages/kcms/src/match/adaptor/json.ts
+++ b/packages/kcms/src/match/adaptor/json.ts
@@ -112,11 +112,11 @@ export class JSONMatchRepository implements MatchRepository {
       }
 
       return {
-        id: entry.id,
-        teamName: entry.teamName,
-        members: entry.members,
-        isMultiWalk: entry.isMultiWalk,
-        category: entry.category,
+        id: entry.getId(),
+        teamName: entry.getTeamName(),
+        members: entry.getMembers(),
+        isMultiWalk: entry.getIsMultiWalk(),
+        category: entry.getCategory(),
       };
     };
 

--- a/packages/kcms/src/match/controller.ts
+++ b/packages/kcms/src/match/controller.ts
@@ -93,10 +93,10 @@ export class MatchController {
       }
 
       return {
-        id: i.id,
-        teamName: i.teamName,
-        isMultiWalk: i.isMultiWalk,
-        category: i.category,
+        id: i.getId(),
+        teamName: i.getTeamName(),
+        isMultiWalk: i.getIsMultiWalk(),
+        category: i.getCategory(),
       };
     };
 

--- a/packages/kcms/src/match/controller.ts
+++ b/packages/kcms/src/match/controller.ts
@@ -101,14 +101,14 @@ export class MatchController {
     };
 
     return {
-      id: i.id,
+      id: i.getId(),
       teams: {
-        left: toTeamJSON(i.teams.left),
-        right: toTeamJSON(i.teams.right),
+        left: toTeamJSON(i.getTeams().left),
+        right: toTeamJSON(i.getTeams().right),
       },
-      matchType: i.matchType,
-      courseIndex: i.courseIndex,
-      results: i.results,
+      matchType: i.getMatchType(),
+      courseIndex: i.getCourseIndex(),
+      results: i.getResults(),
     };
   }
 }

--- a/packages/kcms/src/match/match.test.ts
+++ b/packages/kcms/src/match/match.test.ts
@@ -14,15 +14,15 @@ describe('正しくインスタンスを生成できる', () => {
       courseIndex: 0,
     });
 
-    expect(actual.id).toBe('999');
-    expect(actual.teams).toEqual({
+    expect(actual.getId()).toBe('999');
+    expect(actual.getTeams()).toEqual({
       left: TestEntryData['ElementaryMultiWalk'],
       right: TestEntryData['ElementaryWheel'],
     });
-    expect(actual.results).toBeUndefined();
-    expect(actual.matchType).toBe('primary');
-    expect(actual.courseIndex).toBe(0);
-    expect(actual.time).toBeUndefined();
+    expect(actual.getResults()).toBeUndefined();
+    expect(actual.getMatchType()).toBe('primary');
+    expect(actual.getCourseIndex()).toBe(0);
+    expect(actual.getTime()).toBeUndefined();
     expect(actual.isEnd()).toBe(false);
   });
 
@@ -34,11 +34,14 @@ describe('正しくインスタンスを生成できる', () => {
       courseIndex: 0,
     });
 
-    expect(actual.id).toBe('999');
-    expect(actual.teams).toEqual({ left: TestEntryData['ElementaryMultiWalk'], right: undefined });
-    expect(actual.results).toBeUndefined();
-    expect(actual.matchType).toBe('primary');
-    expect(actual.courseIndex).toBe(0);
-    expect(actual.time).toBeUndefined();
+    expect(actual.getId()).toBe('999');
+    expect(actual.getTeams()).toEqual({
+      left: TestEntryData['ElementaryMultiWalk'],
+      right: undefined,
+    });
+    expect(actual.getResults()).toBeUndefined();
+    expect(actual.getMatchType()).toBe('primary');
+    expect(actual.getCourseIndex()).toBe(0);
+    expect(actual.getTime()).toBeUndefined();
   });
 });

--- a/packages/kcms/src/match/match.ts
+++ b/packages/kcms/src/match/match.ts
@@ -88,15 +88,15 @@ export interface ReconstructMatchArgs {
 
 export class Match {
   // 試合ID
-  private readonly _id: MatchID;
+  private readonly id: MatchID;
   // 試合するチームのID
-  private readonly _teams: MatchTeams;
+  private readonly teams: MatchTeams;
   // 試合種別 primary: 予選, final: 本選
-  private readonly _matchType: 'primary' | 'final';
+  private readonly matchType: 'primary' | 'final';
   // コース番号
-  private readonly _courseIndex: number;
+  private readonly courseIndex: number;
   // 試合の結果
-  private _results?: MatchResultPair | MatchResultFinalPair;
+  private results?: MatchResultPair | MatchResultFinalPair;
 
   private constructor(args: {
     id: MatchID;
@@ -105,45 +105,46 @@ export class Match {
     results?: MatchResultPair | MatchResultFinalPair;
     courseIndex: number;
   }) {
-    this._id = args.id;
-    this._teams = args.teams;
-    this._results = args.results;
-    this._matchType = args.matchType;
-    this._courseIndex = args.courseIndex;
+    this.id = args.id;
+    this.teams = args.teams;
+    this.results = args.results;
+    this.matchType = args.matchType;
+    this.courseIndex = args.courseIndex;
   }
 
-  get id(): MatchID {
-    return this._id;
+  getId(): MatchID {
+    return this.id;
   }
 
-  get teams(): MatchTeams {
-    return this._teams;
+  getTeams(): MatchTeams {
+    return this.teams;
   }
 
-  get matchType(): 'primary' | 'final' {
-    return this._matchType;
+  getMatchType(): 'primary' | 'final' {
+    return this.matchType;
   }
 
-  get courseIndex(): number {
-    return this._courseIndex;
+  getCourseIndex(): number {
+    return this.courseIndex;
   }
 
-  set results(results: MatchResultPair | MatchResultFinalPair) {
-    this._results = results;
+  setResults(results: MatchResultPair | MatchResultFinalPair) {
+    this.results = results;
   }
 
-  get results(): MatchResultPair | MatchResultFinalPair | undefined {
-    return this._results;
+  getResults(): MatchResultPair | MatchResultFinalPair | undefined {
+    return this.results;
   }
 
-  get time(): MatchResultPair | MatchResultFinalPair | undefined {
-    return this._results;
+  // ToDo: Resultを返している意味がわからない
+  getTime(): MatchResultPair | MatchResultFinalPair | undefined {
+    return this.results;
   }
 
   // 既に試合が終了しているか
   public isEnd(): boolean {
     // 結果 NOT undefined -> true
-    return this._results !== undefined;
+    return this.results !== undefined;
   }
 
   public static new(arg: CreateMatchArgs): Match {

--- a/packages/kcms/src/match/service/edit.ts
+++ b/packages/kcms/src/match/service/edit.ts
@@ -17,7 +17,7 @@ export class EditMatchService {
     const match = await this.matchRepository.findByID(id);
     if (Option.isNone(match)) return Result.err(new Error('Match not found'));
 
-    if (args.results !== undefined) match[1].results = args.results;
+    if (args.results !== undefined) match[1].setResults(args.results);
 
     const res = await this.matchRepository.update(match[1]);
     if (Result.isErr(res)) return Result.err(res[1]);

--- a/packages/kcms/src/match/service/generateFinal.test.ts
+++ b/packages/kcms/src/match/service/generateFinal.test.ts
@@ -56,7 +56,7 @@ describe('GenerateFinal1st', () => {
     Result.unwrap(actual).map((v, i) => {
       expect(expected[i]).toStrictEqual({
         left: v.getTeams().left!.getId(),
-        right: v.getTeams().right!.getId()
+        right: v.getTeams().right!.getId(),
       });
     });
   });

--- a/packages/kcms/src/match/service/generateFinal.test.ts
+++ b/packages/kcms/src/match/service/generateFinal.test.ts
@@ -55,8 +55,8 @@ describe('GenerateFinal1st', () => {
 
     Result.unwrap(actual).map((v, i) => {
       expect(expected[i]).toStrictEqual({
-        left: v.teams.left!.id,
-        right: v.teams.right!.id,
+        left: v.getTeams().left!.id,
+        right: v.getTeams().right!.id,
       });
     });
   });
@@ -160,7 +160,7 @@ describe('GenerateFinalNth', () => {
     const res = Option.unwrap(await repository.findByType('final'));
     // 結果を入れ替える
     res.map(async (v) => {
-      v.results = TestData[`${v.teams.left!.id}-${v.teams.right!.id}`];
+      v.setResults(TestData[`${v.getTeams().left!.id}-${v.getTeams().right!.id}`]);
       await repository.update(v);
     });
 
@@ -168,10 +168,10 @@ describe('GenerateFinalNth', () => {
     Result.unwrap(actual).map((v, i) => {
       expect({
         left: {
-          id: v.teams.left!.id,
+          id: v.getTeams().left!.id,
         },
         right: {
-          id: v.teams.right!.id,
+          id: v.getTeams().right!.id,
         },
       }).toStrictEqual(expected2nd[i]);
     });

--- a/packages/kcms/src/match/service/generateFinal.test.ts
+++ b/packages/kcms/src/match/service/generateFinal.test.ts
@@ -55,8 +55,8 @@ describe('GenerateFinal1st', () => {
 
     Result.unwrap(actual).map((v, i) => {
       expect(expected[i]).toStrictEqual({
-        left: v.getTeams().left!.id,
-        right: v.getTeams().right!.id,
+        left: v.getTeams().left!.getId(),
+        right: v.getTeams().right!.getId()
       });
     });
   });
@@ -160,7 +160,7 @@ describe('GenerateFinalNth', () => {
     const res = Option.unwrap(await repository.findByType('final'));
     // 結果を入れ替える
     res.map(async (v) => {
-      v.setResults(TestData[`${v.getTeams().left!.id}-${v.getTeams().right!.id}`]);
+      v.setResults(TestData[`${v.getTeams().left!.getId()}-${v.getTeams().right!.getId()}`]);
       await repository.update(v);
     });
 
@@ -168,10 +168,10 @@ describe('GenerateFinalNth', () => {
     Result.unwrap(actual).map((v, i) => {
       expect({
         left: {
-          id: v.getTeams().left!.id,
+          id: v.getTeams().left!.getId(),
         },
         right: {
-          id: v.getTeams().right!.id,
+          id: v.getTeams().right!.getId(),
         },
       }).toStrictEqual(expected2nd[i]);
     });

--- a/packages/kcms/src/match/service/generateFinal.ts
+++ b/packages/kcms/src/match/service/generateFinal.ts
@@ -102,7 +102,7 @@ export class GenerateFinalMatchService {
 
     return Result.ok(
       res[1]
-        .filter((v) => v.category === 'Open')
+        .filter((v) => v.getCategory() === 'Open')
         .map((v, i): TournamentRank => {
           return {
             rank: i,
@@ -142,7 +142,7 @@ export class GenerateFinalMatchService {
       return Result.err(new Error('Match not found.'));
     }
     // 指定したカテゴリの試合だけ取得
-    const categoryMatch = match[1].filter((v) => v.getTeams().left!.category === category);
+    const categoryMatch = match[1].filter((v) => v.getTeams().left!.getCategory() === category);
 
     // 終了している試合に絞る
     const finishedMatch = categoryMatch.filter((v) => {
@@ -169,7 +169,7 @@ export class GenerateFinalMatchService {
       const res: Entry[] = new Array<Entry>();
       for (const v of match) {
         const winnerID = (v.getResults() as MatchResultFinalPair).winnerID;
-        if (v.getTeams().left!.id == winnerID) {
+        if (v.getTeams().left!.getId() == winnerID) {
           res.push(v.getTeams().left!);
         } else {
           res.push(v.getTeams().right!);

--- a/packages/kcms/src/match/service/generateFinal.ts
+++ b/packages/kcms/src/match/service/generateFinal.ts
@@ -142,13 +142,13 @@ export class GenerateFinalMatchService {
       return Result.err(new Error('Match not found.'));
     }
     // 指定したカテゴリの試合だけ取得
-    const categoryMatch = match[1].filter((v) => v.teams.left!.category === category);
+    const categoryMatch = match[1].filter((v) => v.getTeams().left!.category === category);
 
     // 終了している試合に絞る
     const finishedMatch = categoryMatch.filter((v) => {
       // 終了している条件: resultsがundefinedでない, results.winnerIDに値がある
-      if (v.results === undefined) return false;
-      return (v.results as MatchResultFinalPair).winnerID !== undefined;
+      if (v.getResults() === undefined) return false;
+      return (v.getResults() as MatchResultFinalPair).winnerID !== undefined;
     });
     // N回戦まで終了しているか
     const finishedN = this.isGenerative(this.FINAL_TOURNAMENT_COUNT, finishedMatch.length);
@@ -168,11 +168,11 @@ export class GenerateFinalMatchService {
     const pickWinner = (match: [Match, Match]): Entry[] => {
       const res: Entry[] = new Array<Entry>();
       for (const v of match) {
-        const winnerID = (v.results as MatchResultFinalPair).winnerID;
-        if (v.teams.left!.id == winnerID) {
-          res.push(v.teams.left!);
+        const winnerID = (v.getResults() as MatchResultFinalPair).winnerID;
+        if (v.getTeams().left!.id == winnerID) {
+          res.push(v.getTeams().left!);
         } else {
-          res.push(v.teams.right!);
+          res.push(v.getTeams().right!);
         }
       }
       return res;

--- a/packages/kcms/src/match/service/generatePrimary.test.ts
+++ b/packages/kcms/src/match/service/generatePrimary.test.ts
@@ -24,8 +24,8 @@ describe('予選の対戦表を正しく生成できる', () => {
     expect(Result.isErr(res)).toStrictEqual(false);
     for (const v of Result.unwrap(res)) {
       for (const j of v) {
-        expect(j.teams.left!.id).not.toBe(j.teams.right!.id);
-        expect(j.teams.left!.category).toStrictEqual(j.teams.right!.category);
+        expect(j.teams.left!.getId()).not.toBe(j.teams.right!.getId());
+        expect(j.teams.left!.getCategory()).toStrictEqual(j.teams.right!.getCategory());
       }
     }
   });

--- a/packages/kcms/src/match/service/generatePrimary.ts
+++ b/packages/kcms/src/match/service/generatePrimary.ts
@@ -30,7 +30,7 @@ export class GeneratePrimaryMatchService {
     }
 
     // 分ける(N/M = A...B M[i]にA人、B人を少ない方から)
-    const entry = res[1].filter((v) => v.category === 'Elementary');
+    const entry = res[1].filter((v) => v.getCategory() === 'Elementary');
     console.log(entry.length);
     const entryNum = entry.length;
     // コースごとの参加者数

--- a/packages/kcms/src/match/service/generateRanking.test.ts
+++ b/packages/kcms/src/match/service/generateRanking.test.ts
@@ -66,12 +66,12 @@ describe('GenerateRankingService', () => {
     ];
 
     actual.map((v, i) => {
-      console.log(v.entry.id, v.rank, v.points, v.time);
+      console.log(v.entry.getId, v.rank, v.points, v.time);
       expect({
         rank: v.rank,
         points: v.points,
         time: v.time,
-        id: v.entry.id,
+        id: v.entry.getId(),
       }).toStrictEqual(expected[i]);
     });
   });

--- a/packages/kcms/src/match/service/generateRanking.ts
+++ b/packages/kcms/src/match/service/generateRanking.ts
@@ -1,6 +1,6 @@
 import { TournamentRank } from './generateFinal.js';
 import { Result } from '@mikuroxina/mini-fn';
-import { isMatchResultPair } from '../match.js';
+import {isMatchResultPair, MatchResultPair} from '../match.js';
 import { MatchRepository } from './repository.js';
 
 export class GenerateRankingService {
@@ -20,14 +20,14 @@ export class GenerateRankingService {
     // -> まず全ての対戦を取得
     for (const v of res[1]) {
       // 本選は関係ないので飛ばす
-      if (v.matchType !== 'primary') continue;
+      if (v.getMatchType() !== 'primary') continue;
       // 終わってない場合は飛ばす
-      if (!v.isEnd() || !v.results) continue;
+      if (!v.isEnd() || !v.getResults()) continue;
       // ToDo: Match.categoryがprimaryのときはMatchResultPairに必ずなるようにする
-      if (!isMatchResultPair(v.results)) continue;
+      if (!isMatchResultPair(v.getResults())) continue;
       // 対戦の結果を取って、tournamentRankを作る
-      const left = v.results.left;
-      const right = v.results.right;
+      const left = (v.getResults() as MatchResultPair).left;
+      const right = (v.getResults() as MatchResultPair).right;
 
       // 左チームの結果を追加
       const leftRank = rankBase.find((v) => v.entry.id === left.teamID);
@@ -37,7 +37,7 @@ export class GenerateRankingService {
           rank: 0,
           points: left.points,
           time: left.time,
-          entry: v.teams.left,
+          entry: v.getTeams().left,
         });
       } else {
         // あれば足す
@@ -53,7 +53,7 @@ export class GenerateRankingService {
           rank: 0,
           points: right.points,
           time: right.time,
-          entry: v.teams.right,
+          entry: v.getTeams().right,
         });
       } else {
         // あれば足す

--- a/packages/kcms/src/match/service/generateRanking.ts
+++ b/packages/kcms/src/match/service/generateRanking.ts
@@ -30,7 +30,7 @@ export class GenerateRankingService {
       const right = (v.getResults() as MatchResultPair).right;
 
       // 左チームの結果を追加
-      const leftRank = rankBase.find((v) => v.entry.id === left.teamID);
+      const leftRank = rankBase.find((v) => v.entry.getId() === left.teamID);
       if (!leftRank) {
         // なければ作る
         rankBase.push(<TournamentRank>{
@@ -46,7 +46,7 @@ export class GenerateRankingService {
       }
 
       // 右チームの結果を追加
-      const rightRank = rankBase.find((v) => v.entry.id === right.teamID);
+      const rightRank = rankBase.find((v) => v.entry.getId() === right.teamID);
       if (!rightRank) {
         // なければ作る
         rankBase.push(<TournamentRank>{
@@ -65,10 +65,10 @@ export class GenerateRankingService {
     // 部門ごとに分ける [0]: Elementary, [1]: Open
     const categoryRank: TournamentRank[][] = [[], []];
     for (const v of rankBase) {
-      if (v.entry.category === 'Elementary') {
+      if (v.entry.getCategory() === 'Elementary') {
         categoryRank[0].push(v);
       }
-      if (v.entry.category === 'Open') {
+      if (v.entry.getCategory() === 'Open') {
         categoryRank[1].push(v);
       }
     }

--- a/packages/kcms/src/match/service/generateRanking.ts
+++ b/packages/kcms/src/match/service/generateRanking.ts
@@ -1,6 +1,6 @@
 import { TournamentRank } from './generateFinal.js';
 import { Result } from '@mikuroxina/mini-fn';
-import {isMatchResultPair, MatchResultPair} from '../match.js';
+import { isMatchResultPair, MatchResultPair } from '../match.js';
 import { MatchRepository } from './repository.js';
 
 export class GenerateRankingService {

--- a/packages/kcms/src/match/service/get.test.ts
+++ b/packages/kcms/src/match/service/get.test.ts
@@ -32,8 +32,8 @@ describe('MatchDTO', () => {
     const toDTO = MatchDTO.fromDomain(toDomain);
 
     expect(toDomain.getId()).toStrictEqual(toDTO.id);
-    expect(toDomain.getTeams().left!.id).toStrictEqual(toDTO.teams.left!.id);
-    expect(toDomain.getTeams().right!.id).toStrictEqual(toDTO.teams.right!.id);
+    expect(toDomain.getTeams().left!.getId).toStrictEqual(toDTO.teams.left!.getId);
+    expect(toDomain.getTeams().right!.getId).toStrictEqual(toDTO.teams.right!.getId);
     expect(toDomain.getMatchType()).toStrictEqual(toDTO.matchType);
     expect(toDomain.getCourseIndex()).toStrictEqual(toDTO.courseIndex);
     expect(toDomain.getResults()).toStrictEqual(toDTO.results);

--- a/packages/kcms/src/match/service/get.test.ts
+++ b/packages/kcms/src/match/service/get.test.ts
@@ -10,7 +10,7 @@ describe('GetMatchService', () => {
   const service = new GetMatchService(repository);
 
   it('取得できる', async () => {
-    const res = await service.findById(TestMatchData.ElementaryPrimary.id);
+    const res = await service.findById(TestMatchData.ElementaryPrimary.getId());
 
     expect(Result.isErr(res)).toStrictEqual(false);
     expect(res[1]).toStrictEqual(MatchDTO.fromDomain(TestMatchData.ElementaryPrimary));
@@ -31,11 +31,11 @@ describe('MatchDTO', () => {
     const toDomain = MatchDTO.fromDomain(domain).toDomain();
     const toDTO = MatchDTO.fromDomain(toDomain);
 
-    expect(toDomain.id).toStrictEqual(toDTO.id);
-    expect(toDomain.teams.left!.id).toStrictEqual(toDTO.teams.left!.id);
-    expect(toDomain.teams.right!.id).toStrictEqual(toDTO.teams.right!.id);
-    expect(toDomain.matchType).toStrictEqual(toDTO.matchType);
-    expect(toDomain.courseIndex).toStrictEqual(toDTO.courseIndex);
-    expect(toDomain.results).toStrictEqual(toDTO.results);
+    expect(toDomain.getId()).toStrictEqual(toDTO.id);
+    expect(toDomain.getTeams().left!.id).toStrictEqual(toDTO.teams.left!.id);
+    expect(toDomain.getTeams().right!.id).toStrictEqual(toDTO.teams.right!.id);
+    expect(toDomain.getMatchType()).toStrictEqual(toDTO.matchType);
+    expect(toDomain.getCourseIndex()).toStrictEqual(toDTO.courseIndex);
+    expect(toDomain.getResults()).toStrictEqual(toDTO.results);
   });
 });

--- a/packages/kcms/src/match/service/get.ts
+++ b/packages/kcms/src/match/service/get.ts
@@ -74,7 +74,13 @@ export class MatchDTO {
   }
 
   public static fromDomain(match: Match): MatchDTO {
-    return new MatchDTO(match.id, match.teams, match.matchType, match.courseIndex, match.results);
+    return new MatchDTO(
+      match.getId(),
+      match.getTeams(),
+      match.getMatchType(),
+      match.getCourseIndex(),
+      match.getResults()
+    );
   }
 
   public toDomain(): Match {


### PR DESCRIPTION
close #76 

## 概要
- Match/Entryモデルのゲッターセッターを普通の関数に置き換えました
- その他不要になった部分の削除も行っています