### PR TITLE
fix: `eslint-plugin-react-hooks`をeslint v9に対応させる

### DIFF
--- a/packages/kcmsf/eslint.config.js
+++ b/packages/kcmsf/eslint.config.js
@@ -1,14 +1,17 @@
+import { fixupPluginRules } from "@eslint/compat";
 import { FlatCompat } from "@eslint/eslintrc";
 import js from "@eslint/js";
 import typeScriptESLint from "@typescript-eslint/eslint-plugin";
 import typeScriptESLintParser from "@typescript-eslint/parser";
 import eslintConfigPrettier from "eslint-config-prettier";
+import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
 import vitest from "eslint-plugin-vitest";
 import globals from "globals";
 
 const compat = new FlatCompat();
 
+/** @type {import("eslint").Linter.FlatConfig} */
 export default [
   {
     files: ["src/**/*.{ts,tsx}"],
@@ -19,7 +22,6 @@ export default [
   js.configs.recommended,
   eslintConfigPrettier,
   ...compat.extends("plugin:@typescript-eslint/recommended"),
-  ...compat.extends("plugin:react-hooks/recommended"),
   {
     languageOptions: {
       parser: typeScriptESLintParser,
@@ -32,12 +34,14 @@ export default [
     plugins: {
       "@typescript-eslint": typeScriptESLint,
       "react-refresh": reactRefresh,
+      "react-hooks": fixupPluginRules(reactHooks),
       vitest,
     },
   },
   {
     rules: {
       ...vitest.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
       "react-refresh/only-export-components": [
         "warn",
         { allowConstantExport: true },

--- a/packages/kcmsf/package.json
+++ b/packages/kcmsf/package.json
@@ -26,6 +26,7 @@
     "react-timer-hook": "^3.0.7"
   },
   "devDependencies": {
+    "@eslint/compat": "^1.1.1",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,7 +49,7 @@ importers:
         version: 7.16.0(eslint@9.6.0)(typescript@5.5.3)
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.2(vitest@2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39)))
+        version: 2.0.2(vitest@2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1))
       eslint:
         specifier: ^9.0.0
         version: 9.6.0
@@ -67,7 +67,7 @@ importers:
         version: 4.16.2
       vitest:
         specifier: ^2.0.0
-        version: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39))
+        version: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1)
 
   packages/kcmsf:
     dependencies:
@@ -105,6 +105,9 @@ importers:
         specifier: ^3.0.7
         version: 3.0.7(react@18.3.1)
     devDependencies:
+      '@eslint/compat':
+        specifier: ^1.1.1
+        version: 1.1.1
       '@testing-library/jest-dom':
         specifier: ^6.4.2
         version: 6.4.6(vitest@2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39)))
@@ -134,7 +137,7 @@ importers:
         version: 3.7.0(vite@5.3.3(@types/node@20.14.10)(sugarss@4.0.1(postcss@8.4.39)))
       '@vitest/coverage-v8':
         specifier: ^2.0.0
-        version: 2.0.2(vitest@2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39)))
+        version: 2.0.2(vitest@2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1))
       '@vitest/ui':
         specifier: ^2.0.0
         version: 2.0.2(vitest@2.0.2)
@@ -173,10 +176,10 @@ importers:
         version: 5.5.3
       vite:
         specifier: ^5.0.0
-        version: 5.3.3(@types/node@20.14.10)(sugarss@4.0.1(postcss@8.4.39))
+        version: 5.3.3(@types/node@20.14.10)(sugarss@4.0.1)
       vitest:
         specifier: ^2.0.0
-        version: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39))
+        version: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1)
 
 packages:
 
@@ -592,6 +595,10 @@ packages:
   '@eslint-community/regexpp@4.11.0':
     resolution: {integrity: sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/compat@1.1.1':
+    resolution: {integrity: sha512-lpHyRyplhGPL5mGEh6M9O5nnKk0Gz4bFI+Zu6tKlPpDUN7XshWvH9C/px4UVm87IAANE0W81CEsNGbS1KlzXpA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/config-array@0.17.0':
     resolution: {integrity: sha512-A68TBu6/1mHHuc5YJL0U0VVeGNiklLAL6rRmhTCP2B5XjWLMnrX+HkO+IAXyHvks5cyyY1jjK5ITPQ1HGS2EVA==}
@@ -2720,6 +2727,8 @@ snapshots:
 
   '@eslint-community/regexpp@4.11.0': {}
 
+  '@eslint/compat@1.1.1': {}
+
   '@eslint/config-array@0.17.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
@@ -2999,7 +3008,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
     optionalDependencies:
-      vitest: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39))
+      vitest: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1)
 
   '@testing-library/react@16.0.0(@testing-library/dom@10.3.0)(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -3177,7 +3186,7 @@ snapshots:
   '@vitejs/plugin-react-swc@3.7.0(vite@5.3.3(@types/node@20.14.10)(sugarss@4.0.1(postcss@8.4.39)))':
     dependencies:
       '@swc/core': 1.6.6
-      vite: 5.3.3(@types/node@20.14.10)(sugarss@4.0.1(postcss@8.4.39))
+      vite: 5.3.3(@types/node@20.14.10)(sugarss@4.0.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -3188,11 +3197,11 @@ snapshots:
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.3.3(@types/node@20.14.10)(sugarss@4.0.1(postcss@8.4.39))
+      vite: 5.3.3(@types/node@20.14.10)(sugarss@4.0.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.0.2(vitest@2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39)))':
+  '@vitest/coverage-v8@2.0.2(vitest@2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -3207,7 +3216,7 @@ snapshots:
       strip-literal: 2.1.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39))
+      vitest: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3246,7 +3255,7 @@ snapshots:
       pathe: 1.1.2
       sirv: 2.0.4
       tinyrainbow: 1.2.0
-      vitest: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39))
+      vitest: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1)
 
   '@vitest/utils@2.0.2':
     dependencies:
@@ -3533,7 +3542,7 @@ snapshots:
       eslint: 9.6.0
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 7.16.0(@typescript-eslint/parser@7.16.0(eslint@9.6.0)(typescript@5.5.3))(eslint@9.6.0)(typescript@5.5.3)
-      vitest: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39))
+      vitest: 2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4396,13 +4405,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@2.0.2(@types/node@20.14.10)(sugarss@4.0.1(postcss@8.4.39)):
+  vite-node@2.0.2(@types/node@20.14.10)(sugarss@4.0.1):
     dependencies:
       cac: 6.7.14
       debug: 4.3.5
       pathe: 1.1.2
       tinyrainbow: 1.2.0
-      vite: 5.3.3(@types/node@20.14.10)(sugarss@4.0.1(postcss@8.4.39))
+      vite: 5.3.3(@types/node@20.14.10)(sugarss@4.0.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -4413,7 +4422,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.3.3(@types/node@20.14.10)(sugarss@4.0.1(postcss@8.4.39)):
+  vite@5.3.3(@types/node@20.14.10)(sugarss@4.0.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.39
@@ -4423,7 +4432,7 @@ snapshots:
       fsevents: 2.3.3
       sugarss: 4.0.1(postcss@8.4.39)
 
-  vitest@2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1(postcss@8.4.39)):
+  vitest@2.0.2(@types/node@20.14.10)(@vitest/ui@2.0.2)(jsdom@24.1.0)(sugarss@4.0.1):
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@vitest/expect': 2.0.2
@@ -4441,8 +4450,8 @@ snapshots:
       tinybench: 2.8.0
       tinypool: 1.0.0
       tinyrainbow: 1.2.0
-      vite: 5.3.3(@types/node@20.14.10)(sugarss@4.0.1(postcss@8.4.39))
-      vite-node: 2.0.2(@types/node@20.14.10)(sugarss@4.0.1(postcss@8.4.39))
+      vite: 5.3.3(@types/node@20.14.10)(sugarss@4.0.1)
+      vite-node: 2.0.2(@types/node@20.14.10)(sugarss@4.0.1)
       why-is-node-running: 2.2.2
     optionalDependencies:
       '@types/node': 20.14.10


### PR DESCRIPTION
close #98 

`@eslint/compat`を導入してv9で使用できるようにした