### PR TITLE
fix: kcmsからconfigパッケージを使用できるようにする

### DIFF
--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "CommonJS",
+    "module": "ESNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -5,6 +5,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "moduleResolution": "bundler"
   }
 }

--- a/packages/kcms/tsconfig.json
+++ b/packages/kcms/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "incremental": true,
     "target": "es2022",
-    "module": "Node16",
+    "module": "esNext",
     "outDir": "./build",
     "rootDir": ".",
     "noEmit": true,
@@ -16,7 +16,7 @@
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "Node16",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "pretty": true

--- a/packages/kcms/tsconfig.json
+++ b/packages/kcms/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "incremental": true,
     "target": "es2022",
-    "module": "esNext",
+    "module": "ESNext",
     "outDir": "./build",
     "rootDir": ".",
     "noEmit": true,


### PR DESCRIPTION
close #174 

kcmsの`module`を`ESNext`に、`moduleResolution`を`bundler`に変更した
他のimportが壊れる可能性があるが、今のところ不具合は確認できず