### PR TITLE
fix: configの`target`を`ES2023`に修正

### DIFF
--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES2023",
     "module": "ESNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
kcmsx/configの`tsconfig.json`の`taget`が`ESNext`になっていたので`ES2023`に変更しました