### PR TITLE
feat: /matchをリンクに追加

### DIFF
--- a/packages/kcmsf/src/pages/home.tsx
+++ b/packages/kcmsf/src/pages/home.tsx
@@ -14,6 +14,8 @@ export const Home = () => {
       <Link to="/result">試合結果</Link>
       <br />
       <Link to="/ranking">ランキング</Link>
+      <br />
+      <Link to="/match">エキシビション</Link>
     </>
   );
 };


### PR DESCRIPTION
close #13 
トップページに/matchへのリンクを追加し、エキシビションモードの試合ページに遷移できるようにした。