### PR TITLE
feat: リテラルオブジェクトの配列から型安全に`map`をする`pick`を追加

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -16,6 +16,7 @@
     - [isDepartmentType(value)](#isdepartmenttypevalue)
     - [isMatchType(value)](#ismatchtypevalue)
     - [isRuleName(value)](#isrulenamevalue)
+    - [pick(array, key)](#pickarray-key)
   - [For Developers(WIP)](#for-developerswip)
     - [kcmsx/configをモノレポ内の別のパッケージから使う](#kcmsxconfigをモノレポ内の別のパッケージから使う)
     - [型定義ファイルのディレクトリ構造](#型定義ファイルのディレクトリ構造)
@@ -312,6 +313,30 @@ rules: [
 - 戻り値の型: `value is RuleName`
 
 `RuleName`の型ガードです。`value`が`RuleName`なら`true`を、そうでなければ`false`を返します。
+
+### pick(array, key)
+
+- `array`: `Record<Key, Value>[]`
+- `key`: `Key`
+- 戻り値の型: `Value`
+
+`config`オブジェクトの配列のプロパティから、型安全に各オブジェクトの1つのプロパティをマップする関数です。
+
+<details open>
+<summary>例:</summary>
+
+```ts
+const array = [
+  { value: "A" },
+  { value: "B" },
+  { value: "C" },
+] as const satisfies { value: string }[];
+
+const mappedValues = array.map((o) => o.value); // `("A" | "B" | "C")[]`と型推論されてしまう
+const pickedValues = pick(array, "value"); // `["A", "B", "C"]`と型推論される
+```
+
+</details>
 
 ## For Developers(WIP)
 

--- a/packages/config/eslint.config.js
+++ b/packages/config/eslint.config.js
@@ -34,4 +34,11 @@ export default [
       ...vitest.configs.recommended.rules,
     },
   },
+  {
+    settings: {
+      vitest: {
+        typecheck: true,
+      },
+    },
+  },
 ];

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -10,3 +10,4 @@ export * from "./src/types/derived/rule";
 // utility
 export * from "./src/utility/against";
 export * from "./src/utility/typeGuard";
+export * from "./src/utility/pick"

--- a/packages/config/index.ts
+++ b/packages/config/index.ts
@@ -9,5 +9,5 @@ export * from "./src/types/derived/rule";
 
 // utility
 export * from "./src/utility/against";
+export * from "./src/utility/pick";
 export * from "./src/utility/typeGuard";
-export * from "./src/utility/pick"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "eslint --cache \"src/**/*.ts\" \"index.ts\"",
     "format": "prettier . --write",
-    "test": "vitest run",
+    "test": "vitest run --typecheck",
     "coverage": "vitest run --coverage",
     "check": "prettier --check \"src/**/*.ts\" \"index.ts\" && tsc -p . --noEmit"
   },

--- a/packages/config/src/utility/pick.test-d.ts
+++ b/packages/config/src/utility/pick.test-d.ts
@@ -1,0 +1,20 @@
+import { describe, expectTypeOf, it } from "vitest";
+import { pick } from "./pick";
+
+describe("pickが正しく機能する", () => {
+  it("リテラル型が保存される", () => {
+    const target = [
+      { key: "value1" },
+      { key: "value2" },
+      { key: "value3" },
+    ] as const satisfies { key: string }[];
+
+    const values = pick(target, "key");
+
+    expectTypeOf(values).not.toEqualTypeOf<string[]>();
+    expectTypeOf(values).not.toEqualTypeOf<
+      ("value1" | "value2" | "value3")[]
+    >();
+    expectTypeOf(values).toEqualTypeOf<["value1", "value2", "value3"]>();
+  });
+});

--- a/packages/config/src/utility/pick.test.ts
+++ b/packages/config/src/utility/pick.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { pick } from "./pick";
+
+describe("pickが正しく機能する", () => {
+  it("正しくmapを行う", () => {
+    const target = [
+      { key: "value1" },
+      { key: "value2" },
+      { key: "value3" },
+    ] as const satisfies { key: string }[];
+
+    const values = pick(target, "key");
+
+    expect(values).toEqual(["value1", "value2", "value3"]);
+  });
+});

--- a/packages/config/src/utility/pick.ts
+++ b/packages/config/src/utility/pick.ts
@@ -1,0 +1,13 @@
+export const pick = <
+  TRecord extends Record<string, unknown>,
+  TArray extends readonly [TRecord, ...TRecord[]],
+  TKey extends keyof TArray[number],
+>(
+  array: TArray,
+  key: TKey
+): {
+  [Index in keyof TArray]: TArray[Index][TKey];
+} =>
+  array.map((o) => o[key]) as unknown as {
+    [Index in keyof TArray]: TArray[Index][TKey];
+  };


### PR DESCRIPTION
close #275