### PR TITLE
feat: 予選対戦表の生成ができるように

### DIFF
--- a/packages/kcms/src/match/model/pre.ts
+++ b/packages/kcms/src/match/model/pre.ts
@@ -15,7 +15,7 @@ export interface CreatePreMatchArgs {
   /** @description 試合番号(1始まり) */
   matchIndex: number;
   /** @description チーム1のID 左を走るチーム */
-  teamId1: TeamID;
+  teamId1?: TeamID;
   /** @description チーム2のID 右を走るチーム */
   teamId2?: TeamID;
   /** @description 走行結果 */
@@ -29,8 +29,7 @@ export class PreMatch {
   private readonly id: PreMatchID;
   private readonly courseIndex: number;
   private readonly matchIndex: number;
-  private readonly teamId1: TeamID;
-  // NOTE: 予選参加者は奇数になる可能性があるので2チーム目はいないことがある
+  private readonly teamId1?: TeamID;
   private readonly teamId2?: TeamID;
   private runResults: RunResult[];
 
@@ -59,7 +58,7 @@ export class PreMatch {
     return this.matchIndex;
   }
 
-  getTeamId1(): TeamID {
+  getTeamId1(): TeamID | undefined {
     return this.teamId1;
   }
 

--- a/packages/kcms/src/match/service/generatePre.test.ts
+++ b/packages/kcms/src/match/service/generatePre.test.ts
@@ -8,7 +8,6 @@ describe('GeneratePreMatchService', () => {
   it('正しく予選対戦表を生成できる', async () => {
     const res = await generateService.handle(dummyTeamsName);
 
-    expect(true).toBe(true);
     expect(res[0]).toStrictEqual([
       ['A1', 'B3'],
       ['A4', 'N1'],

--- a/packages/kcms/src/match/service/generatePre.test.ts
+++ b/packages/kcms/src/match/service/generatePre.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { GeneratePreMatchService } from './generatePre';
+
+describe('GeneratePreMatchService', () => {
+  const dummyTeamsName = ['A1', 'A2', 'A3', 'A4', 'B1', 'B2', 'B3', 'C1', 'C2', 'N1', 'N2'];
+  const generateService = new GeneratePreMatchService();
+
+  it('正しく予選対戦表を生成できる', async () => {
+    const res = await generateService.handle(dummyTeamsName);
+
+    expect(true).toBe(true);
+    expect(res[0]).toStrictEqual([
+      ['A1', 'B3'],
+      ['A4', 'N1'],
+      ['B3', 'A1'],
+      ['N1', 'A4'],
+    ]);
+    expect(res[1]).toStrictEqual([
+      ['A2', 'C1'],
+      ['B1', 'N2'],
+      ['C1', 'A2'],
+      ['N2', 'B1'],
+    ]);
+    expect(res[2]).toStrictEqual([
+      ['A3', 'C2'],
+      ['B2', undefined],
+      [undefined, 'A3'],
+      ['C2', 'B2'],
+    ]);
+  });
+});

--- a/packages/kcms/src/match/service/generatePre.test.ts
+++ b/packages/kcms/src/match/service/generatePre.test.ts
@@ -1,30 +1,53 @@
 import { describe, expect, it } from 'vitest';
 import { GeneratePreMatchService } from './generatePre';
+import { DummyRepository } from '../../team/adaptor/dummyRepository';
+import { testTeamData } from '../../testData/entry';
+import { FetchTeamService } from '../../team/service/get';
+import { SnowflakeIDGenerator } from '../../id/main';
+import { DummyPreMatchRepository } from '../adaptor/dummy/preMatchRepository';
+import { Result } from '@mikuroxina/mini-fn';
+import { TeamID } from '../../team/models/team';
+import { config } from 'config';
 
 describe('GeneratePreMatchService', () => {
-  const dummyTeamsName = ['A1', 'A2', 'A3', 'A4', 'B1', 'B2', 'B3', 'C1', 'C2', 'N1', 'N2'];
-  const generateService = new GeneratePreMatchService();
+  const teamRepository = new DummyRepository([...testTeamData.values()]);
+  const fetchService = new FetchTeamService(teamRepository);
+  const generator = new SnowflakeIDGenerator(1, () =>
+    BigInt(new Date('2024/01/01 00:00:00 UTC').getTime())
+  );
+  const preMatchRepository = new DummyPreMatchRepository();
+  const generateService = new GeneratePreMatchService(fetchService, generator, preMatchRepository);
+
+  const expectedTeamPair = [
+    [
+      ['A1', 'B3'],
+      ['A3', 'C2'],
+      ['B1', 'N2'],
+      ['B3', 'A1'],
+      ['C2', 'A3'],
+      ['N2', 'B1'],
+    ],
+    [
+      ['A2', 'B2'],
+      ['A4', 'C1'],
+      ['B2', 'N1'],
+      ['C1', 'A2'],
+      ['N1', 'A4'],
+    ],
+  ];
 
   it('正しく予選対戦表を生成できる', async () => {
-    const res = await generateService.handle(dummyTeamsName);
+    const generated = await generateService.handle('elementary');
+    expect(Result.isOk(generated)).toBe(true);
+    const res = Result.unwrap(generated);
 
-    expect(res[0]).toStrictEqual([
-      ['A1', 'B3'],
-      ['A4', 'N1'],
-      ['B3', 'A1'],
-      ['N1', 'A4'],
-    ]);
-    expect(res[1]).toStrictEqual([
-      ['A2', 'C1'],
-      ['B1', 'N2'],
-      ['C1', 'A2'],
-      ['N2', 'B1'],
-    ]);
-    expect(res[2]).toStrictEqual([
-      ['A3', 'C2'],
-      ['B2', undefined],
-      [undefined, 'A3'],
-      ['C2', 'B2'],
-    ]);
+    for (let i = 0; i < config.match.pre.course.elementary; i++) {
+      const course = res.filter((v) => v.getCourseIndex() === i + 1);
+      const pair = course.map((v) => [
+        testTeamData.get(v.getTeamId1() ?? ('' as TeamID))?.getTeamName(),
+        testTeamData.get(v.getTeamId2() ?? ('' as TeamID))?.getTeamName(),
+      ]);
+      expect(pair).toStrictEqual(expectedTeamPair[i]);
+    }
   });
 });

--- a/packages/kcms/src/match/service/generatePre.ts
+++ b/packages/kcms/src/match/service/generatePre.ts
@@ -1,0 +1,57 @@
+export class GeneratePreMatchService {
+  private readonly COURSE_COUNT = 3;
+
+  async handle(data: string[]): Promise<(string | undefined)[][][]> {
+    // チームをクラブ名でソートする
+    const teams = data.sort();
+
+    // コースの数でスライスする
+    // 初期化時に必要な個数作っておく
+    const slicedTeams: string[][] = new Array(Math.ceil(teams.length / this.COURSE_COUNT)).fill([]);
+    for (let i = 0; i < Math.ceil(teams.length / this.COURSE_COUNT); i++) {
+      // コース数
+      slicedTeams[i] = teams.slice(i * this.COURSE_COUNT, (i + 1) * this.COURSE_COUNT);
+    }
+
+    /* スライスされた配列を転置する
+     * 列数 != 行数の場合、undefinedが入るので、filterで除外している
+     */
+    const transpose = slicedTeams[0]
+      .map((_, i) => slicedTeams.map((r) => r[i]))
+      .map((r) => r.filter((v) => v !== undefined));
+
+    // 配列の要素ごとに、右側のコースを走る相手を決める
+    return transpose.map((v) => {
+      if (v.length === 1) {
+        console.warn('WANING: 1チームだけのコースがあります');
+        return [
+          [v[0], undefined],
+          [undefined, undefined],
+          [undefined, v[0]],
+        ];
+      } else if (v.length === 2) {
+        console.warn('WANING: 2チームだけのコースがあります');
+        return [
+          [v[0], v[1]],
+          [undefined, undefined],
+          [v[1], v[0]],
+        ];
+      } else if (v.length === 3) {
+        console.warn('WANING: 3チームだけのコースがあります');
+        return [
+          [v[0], v[2]],
+          [v[1], undefined],
+          [undefined, v[0]],
+          [v[2], v[1]],
+        ];
+      } else {
+        // ずらす数(floor(配列の長さ/2))
+        const shift = Math.floor(v.length / 2);
+        // ずらした配列を作成
+        const shifted = v.slice(shift).concat(v.slice(0, shift));
+        // ペアを作る
+        return v.map((_, i) => [v[i], shifted[i]]);
+      }
+    });
+  }
+}

--- a/packages/kcms/src/team/controller.ts
+++ b/packages/kcms/src/team/controller.ts
@@ -1,9 +1,10 @@
 import { TeamRepository } from './models/repository.js';
 import { CreateTeamService } from './service/createTeam';
 import { Result, Option } from '@mikuroxina/mini-fn';
-import { FindEntryService } from './service/get.js';
+import { FetchTeamService } from './service/get.js';
 import { DeleteEntryService } from './service/delete.js';
 import { SnowflakeIDGenerator } from '../id/main.js';
+import { DepartmentType } from 'config';
 
 interface baseEntry {
   id: string;
@@ -15,7 +16,7 @@ interface baseEntry {
 
 export class Controller {
   private readonly createTeam: CreateTeamService;
-  private readonly findEntry: FindEntryService;
+  private readonly findEntry: FetchTeamService;
   private readonly deleteService: DeleteEntryService;
 
   constructor(repository: TeamRepository) {
@@ -23,7 +24,7 @@ export class Controller {
       repository,
       new SnowflakeIDGenerator(1, () => BigInt(new Date().getTime()))
     );
-    this.findEntry = new FindEntryService(repository);
+    this.findEntry = new FetchTeamService(repository);
     this.deleteService = new DeleteEntryService(repository);
   }
 
@@ -32,6 +33,7 @@ export class Controller {
     members: string[];
     isMultiWalk: boolean;
     category: 'Elementary' | 'Open';
+    departmentType: DepartmentType;
   }): Promise<Result.Result<Error, baseEntry>> {
     const res = await this.createTeam.create(args);
     if (Result.isErr(res)) {
@@ -57,11 +59,11 @@ export class Controller {
     return Result.ok(
       res[1].map((v) => {
         return {
-          id: v.id,
-          teamName: v.teamName,
-          members: v.members,
-          isMultiWalk: v.isMultiWalk,
-          category: v.category,
+          id: v.getId(),
+          teamName: v.getTeamName(),
+          members: v.getMembers(),
+          isMultiWalk: v.getIsMultiWalk(),
+          category: v.getCategory(),
         };
       })
     );

--- a/packages/kcms/src/team/main.ts
+++ b/packages/kcms/src/team/main.ts
@@ -17,6 +17,7 @@ entryHandler.post('/', zValidator('json', entryRequestSchema), async (c) => {
     members,
     isMultiWalk,
     category,
+    departmentType: category === 'Open' ? 'open' : 'elementary',
   });
   if (Result.isErr(res)) {
     return c.json({ error: errorToCode(res[1]) }, 400);
@@ -48,6 +49,7 @@ entryHandler.post('/bulk', zValidator('json', bulkEntryRequestSchema), async (c)
       members: v.members,
       isMultiWalk: v.isMultiWalk,
       category: v.category,
+      departmentType: v.category === 'Open' ? 'open' : 'elementary',
     });
     if (Result.isErr(res)) {
       return c.json({ error: errorToCode(res[1]) }, 400);

--- a/packages/kcms/src/team/models/team.test.ts
+++ b/packages/kcms/src/team/models/team.test.ts
@@ -9,6 +9,7 @@ describe('正しくインスタンスを生成できる', () => {
       members: ['山田太郎', 'テスト大介'],
       isMultiWalk: false,
       category: 'Open',
+      departmentType: 'open',
       isEntered: true,
     });
 
@@ -26,6 +27,7 @@ describe('正しくインスタンスを生成できる', () => {
       members: ['山田太郎', 'テスト大介'],
       isMultiWalk: false,
       category: 'Open',
+      departmentType: 'open',
       isEntered: true,
       clubName: 'テストクラブ',
     });
@@ -45,6 +47,7 @@ describe('正しくインスタンスを生成できる', () => {
       members: ['山田太郎', 'テスト大介'],
       isMultiWalk: false,
       category: 'Open',
+      departmentType: 'open',
     });
 
     team.enter();
@@ -59,6 +62,7 @@ describe('正しくインスタンスを生成できる', () => {
       members: ['山田太郎', 'テスト大介'],
       isMultiWalk: false,
       category: 'Open',
+      departmentType: 'open',
     });
 
     team.enter();

--- a/packages/kcms/src/team/models/team.ts
+++ b/packages/kcms/src/team/models/team.ts
@@ -1,9 +1,10 @@
 // Elementary: 小学生部門 / Open: オープン部門
 // ToDo: 部門の定義をファイルから読み込むようにする
 import { SnowflakeID } from '../../id/main.js';
+import { DepartmentType } from 'config';
 
 /**
- * @deprecated ToDo: Configで設定されている値を使う
+ * @deprecated この型は廃止予定. {@link DepartmentType}を使うこと
  */
 export type Department = 'Elementary' | 'Open';
 export type TeamID = SnowflakeID<Team>;
@@ -20,6 +21,7 @@ export interface TeamCreateArgs {
    * @deprecated ToDo: Configで設定されている値を使う
    */
   category: Department;
+  departmentType: DepartmentType;
   clubName?: string;
   /**
    * 当日参加するかどうか (エントリーしたかどうか)
@@ -33,6 +35,7 @@ export class Team {
   private readonly members: Array<string>;
   private readonly isMultiWalk: boolean;
   private readonly category: Department;
+  private readonly depatmentType: DepartmentType;
   private readonly clubName?: string;
   private isEntered: boolean;
 
@@ -42,6 +45,7 @@ export class Team {
     _members: Array<string>,
     _isMultiWalk: boolean,
     category: Department,
+    departmentType: DepartmentType,
     isEntered: boolean,
     clubName?: string
   ) {
@@ -52,6 +56,7 @@ export class Team {
     this.category = category;
     this.clubName = clubName;
     this.isEntered = isEntered;
+    this.depatmentType = departmentType;
   }
 
   getId(): TeamID {
@@ -75,6 +80,10 @@ export class Team {
 
   getCategory(): Department {
     return this.category;
+  }
+
+  getDepartmentType(): DepartmentType {
+    return this.depatmentType;
   }
 
   getClubName(): string | undefined {
@@ -109,6 +118,7 @@ export class Team {
       arg.members,
       arg.isMultiWalk,
       arg.category,
+      arg.departmentType,
       false,
       arg.clubName
     );
@@ -121,6 +131,7 @@ export class Team {
       arg.members,
       arg.isMultiWalk,
       arg.category,
+      arg.departmentType,
       arg.isEntered,
       arg.clubName
     );

--- a/packages/kcms/src/team/service/createTeam.test.ts
+++ b/packages/kcms/src/team/service/createTeam.test.ts
@@ -24,6 +24,7 @@ describe('CreateTeamService', () => {
       members: data.getMembers(),
       isMultiWalk: data.getIsMultiWalk(),
       category: data.getCategory(),
+      departmentType: data.getDepartmentType(),
     });
 
     expect(Result.isOk(actual)).toBe(true);
@@ -45,12 +46,14 @@ describe('CreateTeamService', () => {
       members: data.getMembers(),
       isMultiWalk: data.getIsMultiWalk(),
       category: data.getCategory(),
+      departmentType: data.getDepartmentType(),
     });
     const result = await service.create({
       teamName: existsData.getTeamName(),
       members: existsData.getMembers(),
       isMultiWalk: existsData.getIsMultiWalk(),
       category: existsData.getCategory(),
+      departmentType: existsData.getDepartmentType(),
     });
 
     expect(Result.isErr(result)).toBe(true);
@@ -64,12 +67,14 @@ describe('CreateTeamService', () => {
       members: [],
       isMultiWalk: true,
       category: 'Elementary',
+      departmentType: 'elementary',
     });
     const actual = await service.create({
       teamName: team.getTeamName(),
       members: team.getMembers(),
       isMultiWalk: team.getIsMultiWalk(),
       category: team.getCategory(),
+      departmentType: team.getDepartmentType(),
     });
 
     expect(Result.isErr(actual)).toBe(true);
@@ -83,12 +88,14 @@ describe('CreateTeamService', () => {
       members: ['A太郎', 'B太郎', 'C太郎'],
       isMultiWalk: true,
       category: 'Elementary',
+      departmentType: 'elementary',
     });
     const actual = await service.create({
       teamName: team.getTeamName(),
       members: team.getMembers(),
       isMultiWalk: team.getIsMultiWalk(),
       category: team.getCategory(),
+      departmentType: team.getDepartmentType(),
     });
 
     expect(Result.isErr(actual)).toBe(true);

--- a/packages/kcms/src/team/service/createTeam.ts
+++ b/packages/kcms/src/team/service/createTeam.ts
@@ -48,6 +48,7 @@ export class CreateTeamService {
       members: input.members,
       isMultiWalk: input.isMultiWalk,
       category: input.category,
+      departmentType: input.departmentType,
     };
     const team = Team.new(createArgs);
     const res = await this.repository.create(team);

--- a/packages/kcms/src/team/service/get.test.ts
+++ b/packages/kcms/src/team/service/get.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { DummyRepository } from '../adaptor/dummyRepository.js';
-import { EntryDTO, FindEntryService } from './get.js';
+import { FetchTeamService } from './get.js';
 import { Result } from '@mikuroxina/mini-fn';
 import { TestEntryData } from '../../testData/entry.js';
 
 describe('getEntryService', () => {
   const repository = new DummyRepository();
-  const service = new FindEntryService(repository);
+  const service = new FetchTeamService(repository);
 
   const testEntryData = [
     TestEntryData['ElementaryMultiWalk'],
@@ -25,19 +25,19 @@ describe('getEntryService', () => {
     const actual = await service.findAll();
 
     expect(Result.isOk(actual)).toBe(true);
-    expect(actual[1]).toStrictEqual(testEntryData.map((d) => EntryDTO.fromDomain(d)));
+    expect(actual[1]).toStrictEqual(testEntryData);
   });
 
   it('チーム名で取得できる', async () => {
     const actual = await service.findByTeamName(testEntryData[0].getTeamName());
     expect(Result.isOk(actual)).toBe(true);
-    expect(actual[1]).toStrictEqual(EntryDTO.fromDomain(testEntryData[0]));
+    expect(actual[1]).toStrictEqual(testEntryData[0]);
   });
 
   it('チームIDで取得できる', async () => {
     const actual = await service.findByID(testEntryData[0].getId());
     expect(Result.isOk(actual)).toBe(true);
-    expect(actual[1]).toStrictEqual(EntryDTO.fromDomain(testEntryData[0]));
+    expect(actual[1]).toStrictEqual(testEntryData[0]);
   });
 
   it('存在しないときはエラーを返す', async () => {

--- a/packages/kcms/src/team/service/get.ts
+++ b/packages/kcms/src/team/service/get.ts
@@ -1,102 +1,33 @@
 import { TeamRepository } from '../models/repository.js';
-import { Team, TeamID } from '../models/team.js';
+import { Team } from '../models/team.js';
 import { Option, Result } from '@mikuroxina/mini-fn';
 
-export class FindEntryService {
+export class FetchTeamService {
   private readonly repository: TeamRepository;
 
   constructor(repository: TeamRepository) {
     this.repository = repository;
   }
 
-  async findAll(): Promise<Result.Result<Error, Array<EntryDTO>>> {
-    const res = await this.repository.findAll();
-    if (Result.isErr(res)) {
-      return res;
-    }
-
-    const result = res[1].map((entry) => EntryDTO.fromDomain(entry));
-
-    return Result.ok(result);
+  async findAll(): Promise<Result.Result<Error, Team[]>> {
+    return await this.repository.findAll();
   }
 
-  async findByID(id: string): Promise<Result.Result<Error, EntryDTO>> {
+  async findByID(id: string): Promise<Result.Result<Error, Team>> {
     const res = await this.repository.findByID(id);
     if (Option.isNone(res)) {
       return Result.err(new Error('Not found'));
     }
 
-    return Result.ok(EntryDTO.fromDomain(res[1]));
+    return Result.ok(Option.unwrap(res));
   }
 
-  async findByTeamName(name: string): Promise<Result.Result<Error, EntryDTO>> {
+  async findByTeamName(name: string): Promise<Result.Result<Error, Team>> {
     const res = await this.repository.findByTeamName(name);
     if (Option.isNone(res)) {
       return Result.err(new Error('Not found'));
     }
 
-    return Result.ok(EntryDTO.fromDomain(res[1]));
-  }
-}
-
-export class EntryDTO {
-  private readonly _id: string;
-  private readonly _teamName: string;
-  private readonly _members: string[];
-  private readonly _isMultiWalk: boolean;
-  private readonly _category: 'Elementary' | 'Open';
-
-  private constructor(
-    id: string,
-    teamName: string,
-    members: string[],
-    isMultiWalk: boolean,
-    category: 'Elementary' | 'Open'
-  ) {
-    this._id = id;
-    this._teamName = teamName;
-    this._members = members;
-    this._isMultiWalk = isMultiWalk;
-    this._category = category;
-  }
-
-  public static fromDomain(d: Team): EntryDTO {
-    return new EntryDTO(
-      d.getId(),
-      d.getTeamName(),
-      d.getMembers(),
-      d.getIsMultiWalk(),
-      d.getCategory()
-    );
-  }
-
-  public toToDomain(): Team {
-    return Team.new({
-      id: this._id as TeamID,
-      teamName: this._teamName,
-      members: this._members,
-      isMultiWalk: this._isMultiWalk,
-      category: this._category,
-    });
-  }
-
-  get id(): string {
-    return this._id;
-  }
-
-  get teamName(): string {
-    return this._teamName;
-  }
-
-  get members(): string[] {
-    return this._members;
-  }
-
-  get isMultiWalk(): boolean {
-    return this._isMultiWalk;
-  }
-
-  get category(): string {
-    return this._category;
+    return Result.ok(Option.unwrap(res));
   }
 }

--- a/packages/kcms/src/testData/entry.ts
+++ b/packages/kcms/src/testData/entry.ts
@@ -1,4 +1,5 @@
 import { Team, TeamID } from '../team/models/team.js';
+import { DepartmentType } from 'config';
 
 export const TestEntryData = {
   ElementaryMultiWalk: Team.new({
@@ -7,6 +8,7 @@ export const TestEntryData = {
     members: ['TestTaro1'],
     isMultiWalk: true,
     category: 'Elementary',
+    departmentType: 'elementary',
   }),
   ElementaryWheel: Team.new({
     id: '2' as TeamID,
@@ -14,6 +16,7 @@ export const TestEntryData = {
     members: ['TestTaro2'],
     isMultiWalk: false,
     category: 'Elementary',
+    departmentType: 'elementary',
   }),
   // Openで車輪型は存在しない
   OpenMultiWalk: Team.new({
@@ -22,6 +25,7 @@ export const TestEntryData = {
     members: ['TestTaro3'],
     isMultiWalk: true,
     category: 'Open',
+    departmentType: 'open',
   }),
   OpenMultiWalk2: Team.new({
     id: '4' as TeamID,
@@ -29,6 +33,7 @@ export const TestEntryData = {
     members: ['TestTaro4'],
     isMultiWalk: true,
     category: 'Open',
+    departmentType: 'open',
   }),
   // 1の重複
   ElementaryMultiWalkExists: Team.new({
@@ -37,6 +42,7 @@ export const TestEntryData = {
     members: ['TestTaro1'],
     isMultiWalk: true,
     category: 'Elementary',
+    departmentType: 'elementary',
   }),
   // 2の重複
   ElementaryWheelExists: Team.new({
@@ -45,6 +51,7 @@ export const TestEntryData = {
     members: ['TestTaro2'],
     isMultiWalk: false,
     category: 'Elementary',
+    departmentType: 'elementary',
   }),
   // 3の重複
   OpenMultiWalkExists: Team.new({
@@ -53,6 +60,7 @@ export const TestEntryData = {
     members: ['TestTaro3'],
     isMultiWalk: true,
     category: 'Open',
+    departmentType: 'open',
   }),
   NotEntered: Team.reconstruct({
     id: '6' as TeamID,
@@ -60,6 +68,7 @@ export const TestEntryData = {
     members: ['TestTaro6'],
     isMultiWalk: true,
     category: 'Elementary',
+    departmentType: 'elementary',
     isEntered: false,
   }),
   Entered: Team.reconstruct({
@@ -68,60 +77,44 @@ export const TestEntryData = {
     members: ['TestTaro7'],
     isMultiWalk: true,
     category: 'Elementary',
+    departmentType: 'elementary',
     isEntered: true,
   }),
 };
 
-type entryBase<I extends string, M extends boolean, C extends 'Elementary' | 'Open'> = {
-  id: I;
-  teamName: `TestTeam${I}`;
-  members: [`TestTaro${I}`];
-  isMultiWalk: M;
-  category: C;
+const testDataGenerator = (args: {
+  clubName?: string;
+  teamName: string;
+  department: DepartmentType;
+  isEntered: boolean;
+}) => {
+  return Team.reconstruct({
+    id: Math.random().toString() as TeamID,
+    teamName: `${args.clubName ?? 'N'}${args.teamName}`,
+    members: [`TestTaro ${Math.random()}`],
+    isMultiWalk: true,
+    category: args.department === 'elementary' ? 'Elementary' : 'Open',
+    departmentType: args.department,
+    clubName: args.clubName,
+    isEntered: args.isEntered,
+  });
 };
 
-const entryArgsBuilder = <I extends string, M extends boolean, C extends 'Elementary' | 'Open'>(
-  i: I,
-  m: M,
-  c: C
-): entryBase<I, M, C> => {
-  return {
-    id: i,
-    teamName: `TestTeam${i}`,
-    members: [`TestTaro${i}`],
-    isMultiWalk: m,
-    category: c,
-  };
-};
-
-// TestEntrySet テスト用エントリー用データ, Matchのテスト用に偶数にしてある
-// ToDo: Team.newだとエントリーしていない状態で初期化されるので、Team.reconstructを使う
-export const TestEntrySet = {
-  // 小学生部門 多脚型
-  ElementaryMultiWalk: {
-    101: Team.new(entryArgsBuilder('101' as TeamID, true, 'Elementary')),
-    102: Team.new(entryArgsBuilder('102' as TeamID, true, 'Elementary')),
-    103: Team.new(entryArgsBuilder('103' as TeamID, true, 'Elementary')),
-    104: Team.new(entryArgsBuilder('104' as TeamID, true, 'Elementary')),
-    105: Team.new(entryArgsBuilder('105' as TeamID, true, 'Elementary')),
-    106: Team.new(entryArgsBuilder('106' as TeamID, true, 'Elementary')),
-  },
-  // 小学生部門 車輪型
-  ElementaryWheel: {
-    107: Team.new(entryArgsBuilder('107' as TeamID, false, 'Elementary')),
-    108: Team.new(entryArgsBuilder('108' as TeamID, false, 'Elementary')),
-    109: Team.new(entryArgsBuilder('109' as TeamID, false, 'Elementary')),
-    110: Team.new(entryArgsBuilder('110' as TeamID, false, 'Elementary')),
-    111: Team.new(entryArgsBuilder('111' as TeamID, false, 'Elementary')),
-    112: Team.new(entryArgsBuilder('112' as TeamID, false, 'Elementary')),
-  },
-  // オープン部門 (多脚型のみ)
-  OpenMultiWalk: {
-    113: Team.new(entryArgsBuilder('113' as TeamID, false, 'Open')),
-    114: Team.new(entryArgsBuilder('114' as TeamID, false, 'Open')),
-    115: Team.new(entryArgsBuilder('115' as TeamID, false, 'Open')),
-    116: Team.new(entryArgsBuilder('116' as TeamID, false, 'Open')),
-    117: Team.new(entryArgsBuilder('117' as TeamID, false, 'Open')),
-    118: Team.new(entryArgsBuilder('118' as TeamID, false, 'Open')),
-  },
-} as const;
+/*
+ * TestEntrySet テスト用エントリー用データ, Matchのテスト用
+ */
+export const testTeamData: Map<TeamID, Team> = new Map<TeamID, Team>(
+  [
+    testDataGenerator({ clubName: 'A', teamName: '1', department: 'elementary', isEntered: true }),
+    testDataGenerator({ clubName: 'A', teamName: '2', department: 'elementary', isEntered: true }),
+    testDataGenerator({ clubName: 'A', teamName: '3', department: 'elementary', isEntered: true }),
+    testDataGenerator({ clubName: 'A', teamName: '4', department: 'elementary', isEntered: true }),
+    testDataGenerator({ clubName: 'B', teamName: '1', department: 'elementary', isEntered: true }),
+    testDataGenerator({ clubName: 'B', teamName: '2', department: 'elementary', isEntered: true }),
+    testDataGenerator({ clubName: 'B', teamName: '3', department: 'elementary', isEntered: true }),
+    testDataGenerator({ clubName: 'C', teamName: '1', department: 'elementary', isEntered: true }),
+    testDataGenerator({ clubName: 'C', teamName: '2', department: 'elementary', isEntered: true }),
+    testDataGenerator({ teamName: '1', department: 'elementary', isEntered: true }), // N1
+    testDataGenerator({ teamName: '2', department: 'elementary', isEntered: true }), // N2
+  ].map((v) => [v.getId(), v])
+);


### PR DESCRIPTION
close #178 
close #16

## 概要
- #178 のアルゴリズムを実装
- 不要コードの削除

## 追加情報:
- 後から生成された部門で、コース番号が以前に生成された部門のコース番号と重複する(≒ 試合番号が重複する)状態になっています
  - これについては別PRで修正する必要がありそうです
- テストが決めうちでconfigが変更されると落ちるようになっています
  - ある程度動的に動作するようにしないといけなさそうです