### PR TITLE
fix: Pagesのプレビュービルドからもmockが使えるように修正

### DIFF
--- a/packages/mock/src/main.ts
+++ b/packages/mock/src/main.ts
@@ -10,7 +10,10 @@ const app = new Hono();
 
 app.use(
   cors({
-    origin: ["https://kcmsx.pages.dev", "http://localhost:5173"],
+    origin: (origin) =>
+      origin.match(/https:\/\/([a-zA-Z0-9\-]+\.)?kcmsx\.pages\.dev/) // Pagesのプレビュービルドのため
+        ? origin
+        : "http://localhost:5173",
   })
 );
 

--- a/packages/mock/wrangler.toml
+++ b/packages/mock/wrangler.toml
@@ -1,5 +1,6 @@
 name = "kcmsx-mock"
 compatibility_date = "2024-08-07"
+main = "src/main.ts"
 
 # [vars]
 # MY_VAR = "my-variable"


### PR DESCRIPTION
CORSが`https://kcmsx.pages.dev`のみを許可していたので、プレビュービルド用に`https://*.kcmsx.pages.dev`も許可するようにした