### PR TITLE
feat: チーム登録の実装, Nodeで実行できない問題への暫定対応

### DIFF
--- a/packages/kcms/package.json
+++ b/packages/kcms/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "main": "main.js",
   "scripts": {
-    "start": "node ./build/main.js",
-    "dev": "tsx ./src/main.ts",
+    "start": "bun ./build/main.js",
+    "dev": "bun run --watch ./src/main.ts",
     "build": "esbuild ./src/main.ts --bundle --sourcemap --platform=node --target=node16 --format=esm --packages=external --outfile=build/main.js",
     "lint": "eslint --cache \"src/**/*.ts\"",
     "format": "prettier . --write",

--- a/packages/kcms/prisma/migrations/20241003090116_add_unique_team_name/migration.sql
+++ b/packages/kcms/prisma/migrations/20241003090116_add_unique_team_name/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `Team` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Team_name_key" ON "Team"("name");

--- a/packages/kcms/prisma/schema.prisma
+++ b/packages/kcms/prisma/schema.prisma
@@ -15,7 +15,7 @@ datasource db {
 
 model Team {
   id         String  @id
-  name       String
+  name       String  @unique
   robotType  String  @map("robot_type")
   department String
   clubName   String? @map("club_name")

--- a/packages/kcms/src/adaptor.ts
+++ b/packages/kcms/src/adaptor.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prismaClient = new PrismaClient();

--- a/packages/kcms/src/main.ts
+++ b/packages/kcms/src/main.ts
@@ -4,15 +4,16 @@ KCMS - Matz葉ガニロボコン 大会運営支援ツール
 MIT License.
 */
 import { Hono } from 'hono';
-import { serve } from '@hono/node-server';
 import { teamHandler } from './team/main.js';
 import { cors } from 'hono/cors';
 
 const app = new Hono();
 
 app.use('*', cors());
-app.route('/entry', teamHandler);
+app.route('/', teamHandler);
 
-serve(app, (p) => {
-  console.log(`server started at http://${p.address}:${p.port}`);
-});
+// ToDo: config packageのTS読み込み問題により、一時的にBunで直接TSを実行する形に変更した
+export default {
+  port: 3000,
+  fetch: app.fetch,
+};

--- a/packages/kcms/src/team/main.ts
+++ b/packages/kcms/src/team/main.ts
@@ -1,12 +1,18 @@
 import { Controller } from './controller.js';
 import { DummyRepository } from './adaptor/repository/dummyRepository';
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { GetTeamsRoute } from './routing';
+import { GetTeamsRoute, PostTeamsRoute } from './routing';
 import { Result } from '@mikuroxina/mini-fn';
 import { errorToCode } from './adaptor/errors';
+import { PrismaTeamRepository } from './adaptor/repository/prismaRepository';
+import { prismaClient } from '../adaptor';
 
 export const teamHandler = new OpenAPIHono();
-export const controller = new Controller(new DummyRepository());
+console.log(process.env.NODE_ENV);
+const isProduction = process.env.NODE_ENV === 'production';
+export const controller = new Controller(
+  isProduction ? new PrismaTeamRepository(prismaClient) : new DummyRepository()
+);
 
 /**
  * すべてのチームを返す (GET /team)
@@ -18,4 +24,16 @@ teamHandler.openapi(GetTeamsRoute, async (c) => {
   }
 
   return c.json(Result.unwrap(res), 200);
+});
+
+teamHandler.openapi(PostTeamsRoute, async (c) => {
+  const request = c.req.valid('json');
+
+  const res = await controller.create(request);
+  if (Result.isErr(res)) {
+    console.log(res);
+    return c.json({ description: errorToCode(res[1]) }, 400);
+  }
+  const teams = Result.unwrap(res);
+  return c.json(teams, 200);
 });

--- a/packages/kcms/src/team/main.ts
+++ b/packages/kcms/src/team/main.ts
@@ -8,7 +8,6 @@ import { PrismaTeamRepository } from './adaptor/repository/prismaRepository';
 import { prismaClient } from '../adaptor';
 
 export const teamHandler = new OpenAPIHono();
-console.log(process.env.NODE_ENV);
 const isProduction = process.env.NODE_ENV === 'production';
 export const controller = new Controller(
   isProduction ? new PrismaTeamRepository(prismaClient) : new DummyRepository()
@@ -31,7 +30,6 @@ teamHandler.openapi(PostTeamsRoute, async (c) => {
 
   const res = await controller.create(request);
   if (Result.isErr(res)) {
-    console.log(res);
     return c.json({ description: errorToCode(res[1]) }, 400);
   }
   const teams = Result.unwrap(res);

--- a/packages/kcms/src/team/service/createTeam.test.ts
+++ b/packages/kcms/src/team/service/createTeam.test.ts
@@ -19,39 +19,46 @@ describe('CreateTeamService', () => {
 
   it('参加登録できる', async () => {
     const data = TestEntryData['ElementaryMultiWalk'];
-    const actual = await service.create({
-      teamName: data.getTeamName(),
-      members: data.getMembers(),
-      departmentType: data.getDepartmentType(),
-      robotType: 'leg',
-    });
+    const teamRes = await service.create([
+      {
+        teamName: data.getTeamName(),
+        members: data.getMembers(),
+        departmentType: data.getDepartmentType(),
+        robotType: 'leg',
+      },
+    ]);
 
-    expect(Result.isOk(actual)).toBe(true);
-    if (Result.isErr(actual)) {
+    expect(Result.isOk(teamRes)).toBe(true);
+    if (Result.isErr(teamRes)) {
       return;
     }
+    const teams = Result.unwrap(teamRes);
 
-    expect(actual[1].getMembers()).toStrictEqual(['TestTaro1']);
-    expect(actual[1].getTeamName()).toBe('TestTeam1');
-    expect(actual[1].getRobotType()).toBe('leg');
-    expect(actual[1].getDepartmentType()).toBe('elementary');
+    expect(teams[0].getMembers()).toStrictEqual(['TestTaro1']);
+    expect(teams[0].getTeamName()).toBe('TestTeam1');
+    expect(teams[0].getRobotType()).toBe('leg');
+    expect(teams[0].getDepartmentType()).toBe('elementary');
   });
 
   it('チーム名が重複するときはエラー終了する', async () => {
     const data = TestEntryData['ElementaryMultiWalk'];
     const existsData = TestEntryData['ElementaryMultiWalkExists'];
-    await service.create({
-      teamName: data.getTeamName(),
-      members: data.getMembers(),
-      departmentType: data.getDepartmentType(),
-      robotType: 'leg',
-    });
-    const result = await service.create({
-      teamName: existsData.getTeamName(),
-      members: existsData.getMembers(),
-      departmentType: existsData.getDepartmentType(),
-      robotType: 'leg',
-    });
+    await service.create([
+      {
+        teamName: data.getTeamName(),
+        members: data.getMembers(),
+        departmentType: data.getDepartmentType(),
+        robotType: 'leg',
+      },
+    ]);
+    const result = await service.create([
+      {
+        teamName: existsData.getTeamName(),
+        members: existsData.getMembers(),
+        departmentType: existsData.getDepartmentType(),
+        robotType: 'leg',
+      },
+    ]);
 
     expect(Result.isErr(result)).toBe(true);
     expect(result[1]).toStrictEqual(new Error('teamName Exists'));
@@ -65,12 +72,14 @@ describe('CreateTeamService', () => {
       departmentType: 'elementary',
       robotType: 'leg',
     });
-    const actual = await service.create({
-      teamName: team.getTeamName(),
-      members: team.getMembers(),
-      departmentType: team.getDepartmentType(),
-      robotType: team.getRobotType(),
-    });
+    const actual = await service.create([
+      {
+        teamName: team.getTeamName(),
+        members: team.getMembers(),
+        departmentType: team.getDepartmentType(),
+        robotType: team.getRobotType(),
+      },
+    ]);
 
     expect(Result.isErr(actual)).toBe(true);
     expect(actual[1]).toStrictEqual(new Error('no member'));
@@ -84,12 +93,14 @@ describe('CreateTeamService', () => {
       departmentType: 'elementary',
       robotType: 'leg',
     });
-    const actual = await service.create({
-      teamName: team.getTeamName(),
-      members: team.getMembers(),
-      departmentType: team.getDepartmentType(),
-      robotType: team.getRobotType(),
-    });
+    const actual = await service.create([
+      {
+        teamName: team.getTeamName(),
+        members: team.getMembers(),
+        departmentType: team.getDepartmentType(),
+        robotType: team.getRobotType(),
+      },
+    ]);
 
     expect(Result.isErr(actual)).toBe(true);
     expect(actual[1]).toStrictEqual(new Error('too many members'));


### PR DESCRIPTION
## やったこと
close #385 
- チーム登録エンドポイントの実装
  - Controllerのミスを修正
  - ハンドラの書き直し
- Nodeで実行できない問題への暫定対応をした
  - Bunで直接TSを解釈する方法を採用
  - このPRマージ後は暫定的にBunを実行環境に使用します
    - nodeではサーバーの起動ができなくなります
