### PR TITLE
feat: ロボットの設定で表示名を記述できる

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -4,7 +4,7 @@
   - [createConfig(baseConfig, conditions)](#createconfigbaseconfig-conditions)
   - [baseConfig](#baseconfig)
     - [baseConfig.contestName](#baseconfigcontestname)
-    - [baseConfig.robotTypes](#baseconfigrobottypes)
+    - [baseConfig.robots](#baseconfigrobots)
     - [baseConfig.departments](#baseconfigdepartments)
     - [baseConfig.matches](#baseconfigmatches)
     - [baseConfig.rules](#baseconfigrules)
@@ -32,7 +32,7 @@ import { createConfig } from "./utility/createConfig";
 export const config = createConfig(
   {
     contestName: "",
-    robotTypes: [],
+    robots: [],
     departments: [],
     matches: [],
     rules: [],
@@ -52,7 +52,7 @@ export const config = createConfig(
 - 型: `BaseConfig`
 
 主要なほとんどの設定を含むオブジェクトです。
-`contestName`, `robotTypes`, `departments`, `matches`, `rules`, `sponsors`プロパティが必要です。
+`contestName`, `robots`, `departments`, `matches`, `rules`, `sponsors`プロパティが必要です。
 以下でプロパティの詳細について説明しています。
 
 ### baseConfig.contestName
@@ -70,18 +70,35 @@ contestName: "かにロボコン",
 
 </details>
 
-### baseConfig.robotTypes
+### baseConfig.robots
 
-- 型: `string[]`
+- 型: `RobotConfig[]`
 
 ロボットの種別です。車輪型もしくは歩行型、といった種別を定義します。
 1つ以上の種別が必要です。
+以下で、配列の要素である`RobotConfig`のプロパティについて説明しています。
+
+- `type`
+  - 型: `string`
+  - ロボット種別の種別名です。主にプログラム中で使われます。他のロボット種別と重複させることはできません。
+- `name`
+  - 型: `string`
+  - ロボット種別の表示名です。主にフロントエンドでの表示に使われます。
 
 <details open>
 <summary>例: 車輪型と歩行型の2種別の場合</summary>
 
 ```ts
-robotTypes: ["wheel", "leg"],
+robots: [
+  {
+    type: "wheel",
+    name: "車輪型",
+  },
+  {
+    type: "leg",
+    name: "歩行型",
+  },
+],
 ```
 
 </details>
@@ -102,7 +119,7 @@ robotTypes: ["wheel", "leg"],
   - 部門の表示名です。主にフロントエンドでの表示に使われます。
 - `robotTypes`
   - 型: `string[]`
-  - この部門にエントリーできるロボットの種別のリストです。`baseConfig.robotTypes`に指定した値以外を記述することはできません。
+  - この部門にエントリーできるロボットの種別のリストです。`baseConfig.robots`の`type`に指定した値以外を記述することはできません。
 
 <details open>
 <summary>例: 小学生部門とオープン部門の2種別の場合</summary>

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -4,7 +4,16 @@ import { createConfig } from "./utility/createConfig";
 export const config = createConfig(
   {
     contestName: "第2回 Matz葉がにロボコン",
-    robotTypes: ["wheel", "leg"],
+    robots: [
+      {
+        type: "leg",
+        name: "歩行型",
+      },
+      {
+        type: "wheel",
+        name: "車輪型",
+      },
+    ],
     departments: [
       {
         type: "elementary",

--- a/packages/config/src/types/conditionsConfig.ts
+++ b/packages/config/src/types/conditionsConfig.ts
@@ -1,15 +1,16 @@
 import { DepartmentConfig } from "./departmentConfig";
 import { MatchConfig } from "./matchConfig";
+import { RobotConfig } from "./robotConfig";
 import { DerivedPointState, RuleBaseList, RuleCondition } from "./rule";
 
 /**
  * @description すべてのルールに対する{@link RuleCondition}の設定オブジェクトの型
  */
 export type ConditionsConfig<
-  RobotTypes extends string[],
+  Robots extends RobotConfig[],
   RuleBases extends RuleBaseList,
   Matches extends MatchConfig[],
-  Departments extends DepartmentConfig<RobotTypes>[],
+  Departments extends DepartmentConfig<Robots>[],
 > = {
   [K in RuleBases[number]["name"]]?: RuleCondition<
     Matches[number]["type"],

--- a/packages/config/src/types/config.ts
+++ b/packages/config/src/types/config.ts
@@ -1,10 +1,21 @@
 import {
   DepartmentConfig,
   DerivedDepartment,
+  DerivedDepartmentTypes,
   ValidDepartmentConfigs,
 } from "./departmentConfig";
-import { DerivedMatch, MatchConfig, ValidMatchConfigs } from "./matchConfig";
-import { ValidRobotTypes } from "./robotConfig";
+import {
+  DerivedMatch,
+  DerivedMatchTypes,
+  MatchConfig,
+  ValidMatchConfigs,
+} from "./matchConfig";
+import {
+  DerivedRobot,
+  DerivedRobotTypes,
+  RobotConfig,
+  ValidRobotConfigs,
+} from "./robotConfig";
 import {
   DerivedRuleBaseVariant,
   RuleList,
@@ -19,8 +30,8 @@ import { SponsorConfig, ValidSponsorConfigs } from "./sponsorConfig";
  */
 export type BaseConfig<
   ContestName extends string,
-  RobotTypes extends string[],
-  Departments extends DepartmentConfig<RobotTypes>[],
+  Robots extends RobotConfig[],
+  Departments extends DepartmentConfig<Robots>[],
   Matches extends MatchConfig[],
   RuleBaseType extends RuleType,
   RuleBaseInitial extends StateType[RuleBaseType],
@@ -28,8 +39,8 @@ export type BaseConfig<
   Sponsors extends SponsorConfig[],
 > = {
   contestName: ContestName;
-  robotTypes: ValidRobotTypes<RobotTypes>;
-  departments: ValidDepartmentConfigs<RobotTypes, Departments>;
+  robots: ValidRobotConfigs<Robots>;
+  departments: ValidDepartmentConfigs<Robots, Departments>;
   matches: ValidMatchConfigs<Matches>;
   rules: ValidRuleList<RuleBaseType, RuleBaseInitial, RuleBases>;
   sponsors: ValidSponsorConfigs<Sponsors>;
@@ -40,8 +51,8 @@ export type BaseConfig<
  */
 export type Config<
   ContestName extends string,
-  RobotTypes extends string[],
-  Departments extends DepartmentConfig<RobotTypes>[],
+  Robots extends RobotConfig[],
+  Departments extends DepartmentConfig<Robots>[],
   Matches extends MatchConfig[],
   Type extends RuleType,
   Initial extends StateType[Type],
@@ -49,11 +60,18 @@ export type Config<
   Sponsors extends SponsorConfig[],
 > = {
   contestName: ContestName;
-  robotTypes: ValidRobotTypes<RobotTypes>;
-  departments: ValidDepartmentConfigs<RobotTypes, Departments>;
+  robots: ValidRobotConfigs<Robots>;
+  departments: ValidDepartmentConfigs<Robots, Departments>;
   matches: ValidMatchConfigs<Matches>;
   rules: ValidRuleList<Type, Initial, Rules>;
   sponsors: ValidSponsorConfigs<Sponsors>;
-  department: DerivedDepartment<RobotTypes, Departments>;
+  robotTypes: DerivedRobotTypes<ValidRobotConfigs<Robots>>;
+  robot: DerivedRobot<Robots>;
+  departmentTypes: DerivedDepartmentTypes<
+    Robots,
+    ValidDepartmentConfigs<Robots, Departments>
+  >;
+  department: DerivedDepartment<Robots, Departments>;
+  matchTypes: DerivedMatchTypes<ValidMatchConfigs<Matches>>;
   match: DerivedMatch<Matches>;
 };

--- a/packages/config/src/types/departmentConfig.ts
+++ b/packages/config/src/types/departmentConfig.ts
@@ -32,6 +32,14 @@ export type DerivedDepartment<
 };
 
 /**
+ * @description {@link Department}の配列から導出される部門設定の`type`属性の配列
+ */
+export type DerivedDepartmentTypes<
+  Robots extends RobotConfig[],
+  Departments extends DepartmentConfig<Robots>[],
+> = Collect<DepartmentConfig<Robots>, Departments, "type">;
+
+/**
  * @description {@link Departments}が有効か判定する型
  * {@link DepartmentConfig}の`type`属性が重複していたらコンパイルに失敗する
  */

--- a/packages/config/src/types/departmentConfig.ts
+++ b/packages/config/src/types/departmentConfig.ts
@@ -1,10 +1,12 @@
+import { Collect } from "../utility/pick";
+import { RobotConfig } from "./robotConfig";
 import { UniqueRecords } from "./uniqueCollection";
 
 /**
  * @description 1つの部門設定の型
  */
-export type DepartmentConfig<RobotTypes extends string[]> =
-  DerivedDepartmentConfig<string, string, RobotTypes[number][]>;
+export type DepartmentConfig<Robots extends RobotConfig[]> =
+  DerivedDepartmentConfig<string, string, Robots[number]["type"][]>;
 
 /**
  * @description 1つの部門設定の, リテラル型から導出される型
@@ -23,8 +25,8 @@ export type DerivedDepartmentConfig<
  * @description {@link DepartmentConfig}の配列から導出される部門設定のオブジェクト
  */
 export type DerivedDepartment<
-  RobotTypes extends string[],
-  Departments extends DepartmentConfig<RobotTypes>[],
+  Robots extends RobotConfig[],
+  Departments extends DepartmentConfig<Robots>[],
 > = {
   [D in Departments[number] as D["type"]]: Omit<D, "type">;
 };
@@ -34,8 +36,8 @@ export type DerivedDepartment<
  * {@link DepartmentConfig}の`type`属性が重複していたらコンパイルに失敗する
  */
 export type ValidDepartmentConfigs<
-  RobotTypes extends string[],
-  Departments extends DepartmentConfig<RobotTypes>[],
+  Robots extends RobotConfig[],
+  Departments extends DepartmentConfig<Robots>[],
 > =
   UniqueRecords<Departments, "type"> extends infer U
     ? Departments extends U

--- a/packages/config/src/types/matchConfig.ts
+++ b/packages/config/src/types/matchConfig.ts
@@ -1,4 +1,5 @@
 import { DepartmentConfig } from "./departmentConfig";
+import { RobotConfig } from "./robotConfig";
 import { UniqueRecords } from "./uniqueCollection";
 
 /**
@@ -8,9 +9,9 @@ export type MatchConfig = DerivedMatchConfig<
   string,
   string,
   number,
-  string[],
-  DepartmentConfig<string[]>[],
-  DerivedCourseConfig<string[], DepartmentConfig<string[]>[]>
+  RobotConfig[],
+  DepartmentConfig<RobotConfig[]>[],
+  DerivedCourseConfig<RobotConfig[], DepartmentConfig<RobotConfig[]>[]>
 >;
 
 /**
@@ -20,9 +21,9 @@ export type DerivedMatchConfig<
   Type extends string,
   Name extends string,
   LimitSeconds extends number,
-  RobotTypes extends string[],
-  Departments extends DepartmentConfig<RobotTypes>[],
-  Course extends DerivedCourseConfig<RobotTypes, Departments>,
+  Robots extends RobotConfig[],
+  Departments extends DepartmentConfig<Robots>[],
+  Course extends DerivedCourseConfig<Robots, Departments>,
 > = {
   type: Type;
   name: Name;
@@ -34,8 +35,8 @@ export type DerivedMatchConfig<
  * @description 1つのコース設定の, リテラル型から導出される型
  */
 export type DerivedCourseConfig<
-  RobotTypes extends string[],
-  Departments extends DepartmentConfig<RobotTypes>[],
+  Robots extends RobotConfig[],
+  Departments extends DepartmentConfig<Robots>[],
 > = Partial<Record<Departments[number]["type"], number>>;
 
 /**

--- a/packages/config/src/types/matchConfig.ts
+++ b/packages/config/src/types/matchConfig.ts
@@ -1,3 +1,4 @@
+import { Collect } from "../utility/pick";
 import { DepartmentConfig } from "./departmentConfig";
 import { RobotConfig } from "./robotConfig";
 import { UniqueRecords } from "./uniqueCollection";
@@ -45,6 +46,15 @@ export type DerivedCourseConfig<
 export type DerivedMatch<Matches extends MatchConfig[]> = {
   [M in Matches[number] as M["type"]]: Omit<M, "type">;
 };
+
+/**
+ * @description {@link MatchConfig}の配列から導出される試合種別設定の`type`属性の配列
+ */
+export type DerivedMatchTypes<Matches extends MatchConfig[]> = Collect<
+  MatchConfig,
+  Matches,
+  "type"
+>;
 
 /**
  * @description {@link Matches}が有効か判定する型

--- a/packages/config/src/types/robotConfig.ts
+++ b/packages/config/src/types/robotConfig.ts
@@ -1,12 +1,42 @@
-import { UniqueArray } from "./uniqueCollection";
+import { Collect } from "../utility/pick";
+import { UniqueRecords } from "./uniqueCollection";
 
 /**
- * @description RobotTypesが有効か判定する型
- * 重複していたらコンパイルに失敗する
+ * @description 1つのロボット設定の型
  */
-export type ValidRobotTypes<RobotTypes extends readonly string[]> =
-  UniqueArray<RobotTypes> extends infer U
-    ? RobotTypes extends U
-      ? RobotTypes
+export type RobotConfig = DerivedRobotConfig<string, string>;
+
+/**
+ * @description 1つのロボット設定の, リテラル型から導出される型
+ */
+export type DerivedRobotConfig<Type extends string, Name extends string> = {
+  type: Type;
+  name: Name;
+};
+
+/**
+ * @description {@link RobotConfig}の配列から導出されるロボット設定のオブジェクト
+ */
+export type DerivedRobot<Robots extends RobotConfig[]> = {
+  [R in Robots[number] as R["type"]]: Omit<R, "type">;
+};
+
+/**
+ * @description {@link RobotConfig}の配列から導出されるロボット設定の`type`属性の配列
+ */
+export type DerivedRobotTypes<Robots extends RobotConfig[]> = Collect<
+  RobotConfig,
+  Robots,
+  "type"
+>;
+
+/**
+ * @description {@link Robots}が有効か判定する型
+ * {@link RobotConfig}の`type`属性が重複していたらコンパイルに失敗する
+ */
+export type ValidRobotConfigs<Robots extends RobotConfig[]> =
+  UniqueRecords<Robots, "type"> extends infer U
+    ? Robots extends U
+      ? Robots
       : U
     : never;

--- a/packages/config/src/types/ruleList.ts
+++ b/packages/config/src/types/ruleList.ts
@@ -1,6 +1,7 @@
 import { ConditionsConfig } from "./conditionsConfig";
 import { DepartmentConfig } from "./departmentConfig";
 import { MatchConfig } from "./matchConfig";
+import { RobotConfig } from "./robotConfig";
 import { RuleBaseList } from "./rule";
 
 /**
@@ -8,11 +9,11 @@ import { RuleBaseList } from "./rule";
  */
 export type DerivedRuleList<
   RuleBases extends RuleBaseList,
-  RobotTypes extends string[],
+  Robots extends RobotConfig[],
   Matches extends MatchConfig[],
-  Departments extends DepartmentConfig<RobotTypes>[],
+  Departments extends DepartmentConfig<Robots>[],
   Conditions extends ConditionsConfig<
-    RobotTypes,
+    Robots,
     RuleBases,
     Matches,
     Departments

--- a/packages/config/src/types/ruleList.ts
+++ b/packages/config/src/types/ruleList.ts
@@ -12,12 +12,7 @@ export type DerivedRuleList<
   Robots extends RobotConfig[],
   Matches extends MatchConfig[],
   Departments extends DepartmentConfig<Robots>[],
-  Conditions extends ConditionsConfig<
-    Robots,
-    RuleBases,
-    Matches,
-    Departments
-  >,
+  Conditions extends ConditionsConfig<Robots, RuleBases, Matches, Departments>,
 > = {
   [K in keyof RuleBases]: RuleBases[K] &
     Readonly<Conditions[RuleBases[K]["name"]]>;

--- a/packages/config/src/utility/createConfig.test.ts
+++ b/packages/config/src/utility/createConfig.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { DerivedDepartmentConfig } from "../types/departmentConfig";
 import { DerivedCourseConfig, DerivedMatchConfig } from "../types/matchConfig";
 import { DerivedPremiseState } from "../types/premise";
+import { DerivedRobotConfig } from "../types/robotConfig";
 import { DerivedPointState, DerivedRuleBaseVariant } from "../types/rule";
 import { DerivedSponsorConfig, SponsorClass } from "../types/sponsorConfig";
 import { createConfig } from "./createConfig";
@@ -13,7 +14,7 @@ describe("正しい設定を生成できる", () => {
     const config = createConfig(
       {
         contestName: "かにロボコン",
-        robotTypes: ["wheel"],
+        robots: [{ type: "wheel", name: "車輪型" }],
         departments: [
           { type: "elementary", name: "小学生部門", robotTypes: ["wheel"] },
         ],
@@ -35,12 +36,15 @@ describe("正しい設定を生成できる", () => {
           },
         ],
         sponsors: [],
-      } as const,
+      },
       {}
     );
 
     expect(config.contestName).toBe("かにロボコン");
-    expect(config.robotTypes).toEqual(["wheel"]);
+
+    expect(config.robots).toHaveLength(1);
+    expect(config.robots[0].type).toBe("wheel");
+    expect(config.robots[0].name).toBe("車輪型");
 
     expect(config.departments).toHaveLength(1);
     expect(config.departments[0].type).toBe("elementary");
@@ -61,24 +65,34 @@ describe("正しい設定を生成できる", () => {
     expect(config.rules[0].changeable).toBeUndefined();
     expect(config.rules[0].scorable).toBeUndefined();
 
+    expect(config.sponsors).toHaveLength(0);
+
+    expect(config.robotTypes).toEqual(["wheel"]);
+    expect(config.robot.wheel.name).toBe("車輪型");
+
+    expect(config.departmentTypes).toEqual(["elementary"]);
     expect(config.department.elementary.name).toBe("小学生部門");
     expect(config.department.elementary.robotTypes).toEqual(["wheel"]);
 
+    expect(config.matchTypes).toEqual(["pre"]);
     expect(config.match.pre.name).toBe("予選");
     expect(config.match.pre.limitSeconds).toBe(180);
+    expect(config.match.pre.course.elementary).toBe(3);
   });
 
   it("複数項目の設定を生成できる", () => {
-    type RobotTypes = [string, ...string[]];
+    type Robot = DerivedRobotConfig<string, string>;
+    type Robots = [Robot, ...Robot[]];
+    type RobotTypes = [Robot["type"], ...Robot["type"][]];
     type Department = DerivedDepartmentConfig<string, string, RobotTypes>;
     type Departments = [Department, ...Department[]];
     type Match = DerivedMatchConfig<
       string,
       string,
       number,
-      string[],
+      Robots,
       Departments,
-      DerivedCourseConfig<string[], Departments> & { __department0: 0 } // ValidCourseConfigsを通過させるため
+      DerivedCourseConfig<Robots, Departments> & { __department0: 0 } // ValidCourseConfigsを通過させるため
     >;
     type Matches = [Match, ...Match[]];
     type Sponsor = DerivedSponsorConfig<string, SponsorClass, string>;
@@ -88,12 +102,15 @@ describe("正しい設定を生成できる", () => {
 
     const range = [...new Array(10)].map((_, i) => i);
 
-    const robotTypes = range.map((i) => `robot${i}`) as RobotTypes;
+    const robots = range.map((i) => ({
+      type: `robot${i}`,
+      name: `ロボット${i}`,
+    })) as Robots;
     const departments = range.map(
       (i): Department => ({
         type: `department${i}`,
         name: `部門${i}`,
-        robotTypes: robotTypes.slice(0, i + 1) as RobotTypes,
+        robotTypes: robots.slice(0, i + 1).map((r) => r.type) as RobotTypes,
       })
     ) as Departments;
     const matches = range.map(
@@ -136,7 +153,7 @@ describe("正しい設定を生成できる", () => {
     const config = createConfig(
       {
         contestName: "かにロボコン",
-        robotTypes,
+        robots: robots,
         departments,
         matches,
         rules,
@@ -145,11 +162,17 @@ describe("正しい設定を生成できる", () => {
       {}
     );
 
-    expect(config.robotTypes).toEqual(robotTypes);
+    expect(config.robots).toEqual(robots);
     expect(config.departments).toEqual(departments);
     expect(config.matches).toEqual(matches);
     expect(config.rules).toEqual(rules);
     expect(config.sponsors).toEqual(sponsors);
+    expect(config.robotTypes).toEqual(robots.map((r) => r.type));
+    expect(config.departmentTypes).toEqual(departments.map((d) => d.type));
+    expect(config.matchTypes).toEqual(matches.map((m) => m.type));
+    range.map((i) =>
+      expect(config.robot).toHaveProperty([`robot${i}`, "name"], `ロボット${i}`)
+    );
     range.map((i) =>
       expect(config.department).toHaveProperty(
         [`department${i}`, "name"],
@@ -184,7 +207,7 @@ describe("正しい設定を生成できる", () => {
     const config = createConfig(
       {
         contestName: "かにロボコン",
-        robotTypes: ["wheel"],
+        robots: [{ type: "wheel", name: "車輪型" }],
         departments: [
           { type: "elementary", name: "小学生部門", robotTypes: ["wheel"] },
         ],

--- a/packages/config/src/utility/createConfig.ts
+++ b/packages/config/src/utility/createConfig.ts
@@ -12,6 +12,11 @@ import {
   MatchConfig,
 } from "../types/matchConfig";
 import {
+  DerivedRobot,
+  DerivedRobotConfig,
+  RobotConfig,
+} from "../types/robotConfig";
+import {
   DerivedRuleBaseVariant,
   RuleBaseList,
   RuleType,
@@ -20,14 +25,20 @@ import {
 } from "../types/rule";
 import { DerivedRuleList } from "../types/ruleList";
 import { DerivedSponsorConfig, SponsorClass } from "../types/sponsorConfig";
+import { pick } from "./pick";
 
 export const createConfig = <
   ContestName extends string,
   RobotType extends string,
-  RobotTypes extends [RobotType, ...RobotType[]],
+  RobotName extends string,
+  Robot extends DerivedRobotConfig<RobotType, RobotName>,
+  Robots extends [Robot, ...Robot[]],
   DepartmentType extends string,
   DepartmentName extends string,
-  DepartmentRobotTypes extends [RobotTypes[number], ...RobotTypes[number][]],
+  DepartmentRobotTypes extends [
+    Robots[number]["type"],
+    ...Robots[number]["type"][],
+  ],
   Department extends DerivedDepartmentConfig<
     DepartmentType,
     DepartmentName,
@@ -37,12 +48,12 @@ export const createConfig = <
   MatchType extends string,
   MatchName extends string,
   MatchLimitSeconds extends number,
-  MatchCourse extends DerivedCourseConfig<RobotTypes, Departments>,
+  MatchCourse extends DerivedCourseConfig<Robots, Departments>,
   Match extends DerivedMatchConfig<
     MatchType,
     MatchName,
     MatchLimitSeconds,
-    RobotTypes,
+    Robots,
     Departments,
     MatchCourse
   >,
@@ -67,16 +78,11 @@ export const createConfig = <
     SponsorLogo
   >,
   Sponsors extends [] | [Sponsor, ...Sponsor[]],
-  Conditions extends ConditionsConfig<
-    RobotTypes,
-    RuleBases,
-    Matches,
-    Departments
-  >,
+  Conditions extends ConditionsConfig<Robots, RuleBases, Matches, Departments>,
 >(
   baseConfig: BaseConfig<
     ContestName,
-    RobotTypes,
+    Robots,
     Departments,
     Matches,
     RuleBaseType,
@@ -84,30 +90,30 @@ export const createConfig = <
     RuleBases,
     Sponsors
   >,
-  conditions: ConditionsConfig<RobotTypes, RuleBases, Matches, Departments>
+  conditions: ConditionsConfig<Robots, RuleBases, Matches, Departments>
 ): Readonly<
   Config<
     ContestName,
-    RobotTypes,
+    Robots,
     Departments,
     Matches,
     RuleBaseType,
     RuleBaseInitial,
-    DerivedRuleList<RuleBases, RobotTypes, Matches, Departments, Conditions>,
+    DerivedRuleList<RuleBases, Robots, Matches, Departments, Conditions>,
     Sponsors
   >
 > => ({
   contestName: baseConfig.contestName,
-  robotTypes: baseConfig.robotTypes,
+  robots: baseConfig.robots,
   departments: baseConfig.departments,
   matches: baseConfig.matches,
   rules: baseConfig.rules.map<
     DerivedRuleList<
       RuleBaseList,
-      RobotTypes,
+      Robots,
       Matches,
       Departments,
-      ConditionsConfig<RobotTypes, RuleBaseList, Matches, Departments>
+      ConditionsConfig<Robots, RuleBaseList, Matches, Departments>
     >[number]
   >((ruleBase) => {
     const name: RuleBases[number]["name"] = ruleBase.name;
@@ -120,14 +126,22 @@ export const createConfig = <
   }) as ValidRuleList<
     RuleBaseType,
     RuleBaseInitial,
-    DerivedRuleList<RuleBases, RobotTypes, Matches, Departments, Conditions>
+    DerivedRuleList<RuleBases, Robots, Matches, Departments, Conditions>
   >,
   sponsors: baseConfig.sponsors,
+  robotTypes: pick(baseConfig.robots, "type"),
+  robot: Object.fromEntries(
+    baseConfig.robots.map<[Robots[number]["type"], Omit<RobotConfig, "type">]>(
+      ({ type, name }) => [type, { name }]
+    )
+  ) as DerivedRobot<Robots>,
+  departmentTypes: pick(baseConfig.departments, "type"),
   department: Object.fromEntries(
     baseConfig.departments.map<
-      [Departments[number]["type"], Omit<DepartmentConfig<RobotTypes>, "type">]
+      [Departments[number]["type"], Omit<DepartmentConfig<Robots>, "type">]
     >(({ type, name, robotTypes }) => [type, { name, robotTypes }])
-  ) as DerivedDepartment<RobotTypes, Departments>,
+  ) as DerivedDepartment<Robots, Departments>,
+  matchTypes: pick(baseConfig.matches, "type"),
   match: Object.fromEntries(
     baseConfig.matches.map<
       [Matches[number]["type"], Omit<MatchConfig, "type">]

--- a/packages/config/src/utility/pick.ts
+++ b/packages/config/src/utility/pick.ts
@@ -1,3 +1,14 @@
+/**
+ * @description リテラル配列`TArray`内のレコードの`TKey`属性を取り出した配列の型
+ */
+export type Collect<
+  TRecord extends Record<string, unknown>,
+  TArray extends readonly TRecord[],
+  TKey extends keyof TArray[number],
+> = {
+  [Index in keyof TArray]: TArray[Index][TKey];
+};
+
 export const pick = <
   TRecord extends Record<string, unknown>,
   TArray extends readonly [TRecord, ...TRecord[]],
@@ -5,9 +16,5 @@ export const pick = <
 >(
   array: TArray,
   key: TKey
-): {
-  [Index in keyof TArray]: TArray[Index][TKey];
-} =>
-  array.map((o) => o[key]) as unknown as {
-    [Index in keyof TArray]: TArray[Index][TKey];
-  };
+): Collect<TRecord, TArray, TKey> =>
+  array.map((o) => o[key]) as unknown as Collect<TRecord, TArray, TKey>;


### PR DESCRIPTION
close #398

その他:
- `robotTypes`は`robots`から導出される形にして残しています。
- ↑に合わせ、`departmentTypes`と`matchTypes`も用意しました。