### PR TITLE
feat: エキシビションマッチで歩行型かどうかを入力できる

### DIFF
--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -116,6 +116,10 @@ export const config = createConfig(
   },
   {
     multiWalk: {
+      visible: (state) => !state.matchInfo, // エキシビションモードでのみ表示
+      changeable: (state) =>
+        !state.matchInfo && // エキシビションモードでのみマニュアル変更可能
+        !state.matchState[state.side].getPointState().finish,
       scorable: (state) =>
         !state.matchInfo || // エキシビションモードでは通常通り加算可能
         state.matchInfo.teams[state.side].robotType == "leg", // 通常の試合では歩行型のときのみ加算可能

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -51,7 +51,7 @@ export const config = createConfig(
         name: "multiWalk",
         label: "歩行型",
         type: "single",
-        initial: false,
+        initial: true, // conditionsの`scorable`で制御する
         point: (done: boolean) => (done ? 2 : 0),
       },
       {
@@ -116,7 +116,9 @@ export const config = createConfig(
   },
   {
     multiWalk: {
-      visible: () => false,
+      scorable: (state) =>
+        !state.matchInfo || // エキシビションモードでは通常通り加算可能
+        state.matchInfo.teams[state.side].robotType == "leg", // 通常の試合では歩行型のときのみ加算可能
     },
     leaveBase: {
       changeable: (state) =>

--- a/packages/kcmsf/src/pages/match.tsx
+++ b/packages/kcmsf/src/pages/match.tsx
@@ -38,14 +38,7 @@ export const Match = () => {
   const isExhibition = !id || !matchType;
   const [matchInfo, setMatchInfo] = useState<MatchInfo>();
   const [matchJudge, setMatchJudge] = useState<Judge | undefined>(
-    isExhibition
-      ? new Judge(
-          { multiWalk: false },
-          { multiWalk: false },
-          { matchInfo },
-          { matchInfo }
-        )
-      : undefined
+    isExhibition ? new Judge({}, {}, { matchInfo }, { matchInfo }) : undefined
   );
   useEffect(() => {
     if (isExhibition) return;
@@ -86,20 +79,7 @@ export const Match = () => {
         },
       };
       setMatchInfo(matchInfo);
-      setMatchJudge(
-        new Judge(
-          {
-            multiWalk:
-              !isExhibition && matchInfo?.teams.left.robotType == "leg",
-          },
-          {
-            multiWalk:
-              !isExhibition && matchInfo?.teams.right.robotType == "leg",
-          },
-          { matchInfo },
-          { matchInfo }
-        )
-      );
+      setMatchJudge(new Judge({}, {}, { matchInfo }, { matchInfo }));
     };
     fetchMatchInfo();
   }, [id, isExhibition, matchType]);


### PR DESCRIPTION
close #397 

`multiWalk`は、`scorable`を使って得点が制御されるようになりました。
仕組み上初期値を`true`にせざるを得ず、エキシビションマッチでは最初から歩行型がチェックされた状態から始まります。
