### PR TITLE
feat: MatchAPI.getAllMatchを実装

### DIFF
--- a/packages/kcms/src/main.ts
+++ b/packages/kcms/src/main.ts
@@ -6,11 +6,13 @@ MIT License.
 import { Hono } from 'hono';
 import { teamHandler } from './team/main.js';
 import { cors } from 'hono/cors';
+import { matchHandlers } from './match/main';
 
 const app = new Hono();
 
 app.use('*', cors());
 app.route('/', teamHandler);
+app.route('/', matchHandlers);
 
 // ToDo: config packageのTS読み込み問題により、一時的にBunで直接TSを実行する形に変更した
 export default {

--- a/packages/kcms/src/match/adaptor/controller/match.ts
+++ b/packages/kcms/src/match/adaptor/controller/match.ts
@@ -1,0 +1,73 @@
+import { GetMatchService } from '../../service/get';
+import { z } from '@hono/zod-openapi';
+import { GetMatchResponseSchema } from '../validator/match';
+import { Result } from '@mikuroxina/mini-fn';
+import { DepartmentType } from 'config';
+import { FetchTeamService } from '../../../team/service/get';
+import { TeamID } from '../../../team/models/team';
+
+export class MatchController {
+  constructor(
+    private readonly getMatchService: GetMatchService,
+    private readonly fetchTeamService: FetchTeamService
+  ) {}
+
+  async getAllMatch(): Promise<Result.Result<Error, z.infer<typeof GetMatchResponseSchema>>> {
+    const res = await this.getMatchService.findAll();
+    if (Result.isErr(res)) return res;
+    const match = Result.unwrap(res);
+
+    const teamsRes = await this.fetchTeamService.findAll();
+    if (Result.isErr(teamsRes)) return teamsRes;
+    const teams = Result.unwrap(teamsRes);
+
+    const teamMap = new Map(teams.map((v) => [v.getId(), v]));
+
+    /**
+     * ToDo: 試合の部門を取得できるようにする
+     *       試合に参加するチーム情報を取得する
+     */
+    return Result.ok({
+      pre: match.pre.map((v) => {
+        const getTeam = (
+          teamID: TeamID | undefined
+        ): { id: string; teamName: string } | undefined => {
+          if (!teamID) return undefined;
+          const getTeam = teamMap.get(teamID);
+          if (!getTeam) return undefined;
+          return {
+            id: getTeam.getId(),
+            teamName: getTeam.getTeamName(),
+          };
+        };
+        const getTeamDepartmentType = (
+          left: TeamID | undefined,
+          right: TeamID | undefined
+        ): DepartmentType => {
+          if (!left && !right) throw new Error('Both teamID is undefined');
+          if (!left) {
+            return teamMap.get(right!)!.getDepartmentType();
+          }
+          return teamMap.get(left)!.getDepartmentType();
+        };
+
+        return {
+          id: v.getId(),
+          matchCode: `${v.getCourseIndex()}-${v.getMatchIndex()}`,
+          departmentType: getTeamDepartmentType(v.getTeamId1(), v.getTeamId2()),
+          leftTeam: getTeam(v.getTeamId1()),
+          rightTeam: getTeam(v.getTeamId2()),
+          runResults: v.getRunResults().map((v) => ({
+            id: v.getId(),
+            teamID: v.getTeamId(),
+            points: v.getPoints(),
+            goalTimeSeconds: v.getGoalTimeSeconds(),
+            finishState: v.isGoal() ? ('goal' as const) : ('finished' as const),
+          })),
+        };
+      }),
+      // ToDo: 本戦試合を取得できるようにする
+      main: [],
+    });
+  }
+}

--- a/packages/kcms/src/match/adaptor/controller/match.ts
+++ b/packages/kcms/src/match/adaptor/controller/match.ts
@@ -13,9 +13,9 @@ export class MatchController {
   ) {}
 
   async getAll(): Promise<Result.Result<Error, z.infer<typeof GetMatchResponseSchema>>> {
-    const matchRes = await this.getMatchService.findAll();
-    if (Result.isErr(matchRes)) return matchRes;
-    const match = Result.unwrap(matchRes);
+    const matchesRes = await this.getMatchService.findAll();
+    if (Result.isErr(matchesRes)) return matchesRes;
+    const match = Result.unwrap(matchesRes);
 
     const teamsRes = await this.fetchTeamService.findAll();
     if (Result.isErr(teamsRes)) return teamsRes;

--- a/packages/kcms/src/match/adaptor/controller/match.ts
+++ b/packages/kcms/src/match/adaptor/controller/match.ts
@@ -45,10 +45,7 @@ export class MatchController {
           right: TeamID | undefined
         ): DepartmentType => {
           if (!left && !right) throw new Error('Both teamID is undefined');
-          if (!left) {
-            return teamMap.get(right!)!.getDepartmentType();
-          }
-          return teamMap.get(left)!.getDepartmentType();
+          return teamMap.get(left || right!)!.getDepartmentType();
         };
 
         return {

--- a/packages/kcms/src/match/adaptor/validator/match.ts
+++ b/packages/kcms/src/match/adaptor/validator/match.ts
@@ -20,7 +20,7 @@ const RunResultSchema = z.object({
   finishState: z.enum(['goal', 'finished']).openapi({ example: 'goal' }),
 });
 
-const PreSchema = z.object({
+export const PreSchema = z.object({
   id: z.string().openapi({ example: '320984' }),
   matchCode: z.string().openapi({ example: '1-3' }),
   departmentType: z.enum(config.departmentTypes).openapi({ example: config.departments[0].type }),

--- a/packages/kcms/src/match/main.ts
+++ b/packages/kcms/src/match/main.ts
@@ -1,0 +1,39 @@
+import { MatchController } from './adaptor/controller/match';
+import { GetMatchService } from './service/get';
+import { PrismaPreMatchRepository } from './adaptor/prisma/preMatchRepository';
+import { prismaClient } from '../adaptor';
+import { DummyPreMatchRepository } from './adaptor/dummy/preMatchRepository';
+import { PrismaMainMatchRepository } from './adaptor/prisma/mainMatchRepository';
+import { DummyMainMatchRepository } from './adaptor/dummy/mainMatchRepository';
+import { FetchTeamService } from '../team/service/get';
+import { PrismaTeamRepository } from '../team/adaptor/repository/prismaRepository';
+import { DummyRepository } from '../team/adaptor/repository/dummyRepository';
+import { OpenAPIHono } from '@hono/zod-openapi';
+import { GetMatchRoute } from './routing';
+import { Result } from '@mikuroxina/mini-fn';
+
+const isProduction = process.env.NODE_ENV === 'production';
+const preMatchRepository = isProduction
+  ? new PrismaPreMatchRepository(prismaClient)
+  : new DummyPreMatchRepository();
+const mainMatchRepository = isProduction
+  ? new PrismaMainMatchRepository(prismaClient)
+  : new DummyMainMatchRepository();
+const teamRepository = isProduction
+  ? new PrismaTeamRepository(prismaClient)
+  : new DummyRepository();
+
+const getMatchService = new GetMatchService(preMatchRepository, mainMatchRepository);
+const fetchTeamService = new FetchTeamService(teamRepository);
+const matchController = new MatchController(getMatchService, fetchTeamService);
+
+export const matchHandlers = new OpenAPIHono();
+
+matchHandlers.openapi(GetMatchRoute, async (c) => {
+  const res = await matchController.getAllMatch();
+  if (Result.isErr(res)) {
+    return c.json({ description: res[1].message }, 400);
+  }
+
+  return c.json(res[1], 200);
+});

--- a/packages/kcms/src/match/main.ts
+++ b/packages/kcms/src/match/main.ts
@@ -30,7 +30,7 @@ const matchController = new MatchController(getMatchService, fetchTeamService);
 export const matchHandlers = new OpenAPIHono();
 
 matchHandlers.openapi(GetMatchRoute, async (c) => {
-  const res = await matchController.getAllMatch();
+  const res = await matchController.getAll();
   if (Result.isErr(res)) {
     return c.json({ description: res[1].message }, 400);
   }


### PR DESCRIPTION
## やったこと
close #428  
- `GET /match`(全試合取得)を実装
  - MainMatchは返していません
- MatchにdepartmentTypeを追加