### PR TITLE
feat: 試合生成エンドポイントを実装

### DIFF
--- a/packages/kcms/src/match/adaptor/controller/match.ts
+++ b/packages/kcms/src/match/adaptor/controller/match.ts
@@ -3,6 +3,7 @@ import { z } from '@hono/zod-openapi';
 import {
   GetMatchIdResponseSchema,
   GetMatchResponseSchema,
+  PostMatchGenerateResponseSchema,
   PreSchema,
   RunResultSchema,
 } from '../validator/match';
@@ -12,7 +13,6 @@ import { TeamID } from '../../../team/models/team';
 import { GeneratePreMatchService } from '../../service/generatePre';
 import { DepartmentType, MatchType } from 'config';
 import { MainMatchID } from '../../model/main';
-import { MatchType } from 'config';
 import { PreMatch, PreMatchID } from '../../model/pre';
 
 export class MatchController {
@@ -96,6 +96,7 @@ export class MatchController {
         };
       })
     );
+  }
 
   async getMatchByID<T extends MatchType>(
     matchType: T,

--- a/packages/kcms/src/match/adaptor/controller/match.ts
+++ b/packages/kcms/src/match/adaptor/controller/match.ts
@@ -9,7 +9,7 @@ import { Result } from '@mikuroxina/mini-fn';
 import { FetchTeamService } from '../../../team/service/get';
 import { TeamID } from '../../../team/models/team';
 import { GeneratePreMatchService } from '../../service/generatePre';
-import { DepartmentType } from 'config';
+import { DepartmentType, MatchType } from 'config';
 
 export class MatchController {
   constructor(
@@ -68,7 +68,7 @@ export class MatchController {
   }
 
   async generateMatch(
-    matchType: 'pre' | 'main',
+    matchType: MatchType,
     departmentType: DepartmentType
   ): Promise<Result.Result<Error, z.infer<typeof PostMatchGenerateResponseSchema>>> {
     // ToDo: 本戦試合を生成できるようにする
@@ -88,13 +88,7 @@ export class MatchController {
           departmentType: v.getDepartmentType(),
           leftTeamID: v.getTeamId1(),
           rightTeamID: v.getTeamId2(),
-          runResults: [] as {
-            id: string;
-            teamID: string;
-            points: number;
-            goalTimeSeconds: number | null;
-            finishState: 'goal' | 'finished';
-          }[],
+          runResults: [],
         };
       })
     );

--- a/packages/kcms/src/match/adaptor/controller/match.ts
+++ b/packages/kcms/src/match/adaptor/controller/match.ts
@@ -1,14 +1,16 @@
 import { GetMatchService } from '../../service/get';
 import { z } from '@hono/zod-openapi';
-import { GetMatchResponseSchema, PreSchema } from '../validator/match';
+import { GetMatchResponseSchema, PostMatchGenerateResponseSchema, PreSchema } from "../validator/match";
 import { Result } from '@mikuroxina/mini-fn';
 import { FetchTeamService } from '../../../team/service/get';
 import { TeamID } from '../../../team/models/team';
+import { GeneratePreMatchService } from "../../service/generatePre";
 
 export class MatchController {
   constructor(
     private readonly getMatchService: GetMatchService,
-    private readonly fetchTeamService: FetchTeamService
+    private readonly fetchTeamService: FetchTeamService,
+    private readonly generatePreMatchService: GeneratePreMatchService
   ) {}
 
   async getAll(): Promise<Result.Result<Error, z.infer<typeof GetMatchResponseSchema>>> {
@@ -58,5 +60,23 @@ export class MatchController {
       // ToDo: 本戦試合を取得できるようにする
       main: [],
     });
+  }
+  async generateMatch(matchType: "pre" , departmentType: DepartmentType): Promise<Result.Result<Error, z.infer<typeof PostMatchGenerateResponseSchema>> {
+    // ToDo: 本戦試合を生成できるようにする
+
+    const res = await this.generatePreMatchService.handle(departmentType);
+    if (Result.isErr(res)) return res;
+    const matches = Result.unwrap(res);
+
+    return Result.ok(
+      matches.map(v => {
+        return {
+          id: v.getId(),
+          matchCode: `${v.getCourseIndex()}-${v.getMatchIndex()}`,
+          departmentType: ,
+          runResults: []
+        }
+      }));
+
   }
 }

--- a/packages/kcms/src/match/adaptor/validator/match.ts
+++ b/packages/kcms/src/match/adaptor/validator/match.ts
@@ -98,17 +98,21 @@ export const PostMatchGenerateResponseSchema = z.array(
     PreSchema.omit({
       rightTeam: true,
       leftTeam: true,
-    }).extend({
-      leftTeamID: z.string().optional().openapi({ example: '45098607' }),
-      rightTeamID: z.string().optional().openapi({ example: '2230392' }),
-    }),
+    })
+      .extend({
+        leftTeamID: z.string().optional().openapi({ example: '45098607' }),
+        rightTeamID: z.string().optional().openapi({ example: '2230392' }),
+      })
+      .array(),
     MainSchema.omit({
       team1: true,
       team2: true,
-    }).extend({
-      team1ID: z.string().optional().openapi({ example: '45098607' }),
-      team2ID: z.string().optional().openapi({ example: '2230392' }),
-    }),
+    })
+      .extend({
+        team1ID: z.string().optional().openapi({ example: '45098607' }),
+        team2ID: z.string().optional().openapi({ example: '2230392' }),
+      })
+      .array(),
   ])
 );
 

--- a/packages/kcms/src/match/adaptor/validator/match.ts
+++ b/packages/kcms/src/match/adaptor/validator/match.ts
@@ -98,12 +98,10 @@ export const PostMatchGenerateResponseSchema = z.array(
     PreSchema.omit({
       rightTeam: true,
       leftTeam: true,
-    })
-      .extend({
-        leftTeamID: z.string().optional().openapi({ example: '45098607' }),
-        rightTeamID: z.string().optional().openapi({ example: '2230392' }),
-      })
-      .array(),
+    }).extend({
+      leftTeamID: z.string().optional().openapi({ example: '45098607' }),
+      rightTeamID: z.string().optional().openapi({ example: '2230392' }),
+    }),
     MainSchema.omit({
       team1: true,
       team2: true,

--- a/packages/kcms/src/match/main.ts
+++ b/packages/kcms/src/match/main.ts
@@ -9,14 +9,12 @@ import { FetchTeamService } from '../team/service/get';
 import { PrismaTeamRepository } from '../team/adaptor/repository/prismaRepository';
 import { DummyRepository } from '../team/adaptor/repository/dummyRepository';
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { GetMatchRoute, PostMatchGenerateRoute } from './routing';
+import { GetMatchIdRoute, GetMatchRoute, PostMatchGenerateRoute } from './routing';
 import { Result } from '@mikuroxina/mini-fn';
 import { GeneratePreMatchService } from './service/generatePre';
 import { SnowflakeIDGenerator } from '../id/main';
-import { GetMatchIdRoute, GetMatchRoute } from './routing';
 import { PreMatchID } from './model/pre';
 import { MainMatchID } from './model/main';
-
 
 const isProduction = process.env.NODE_ENV === 'production';
 const preMatchRepository = isProduction
@@ -64,7 +62,7 @@ matchHandlers.openapi(PostMatchGenerateRoute, async (c) => {
 
   return c.json(res[1], 200);
 });
-                      
+
 matchHandlers.openapi(GetMatchIdRoute, async (c) => {
   const { matchType, matchID } = c.req.valid('param');
 

--- a/packages/kcms/src/match/main.ts
+++ b/packages/kcms/src/match/main.ts
@@ -9,8 +9,10 @@ import { FetchTeamService } from '../team/service/get';
 import { PrismaTeamRepository } from '../team/adaptor/repository/prismaRepository';
 import { DummyRepository } from '../team/adaptor/repository/dummyRepository';
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { GetMatchRoute } from './routing';
+import { GetMatchRoute, PostMatchGenerateRoute } from './routing';
 import { Result } from '@mikuroxina/mini-fn';
+import { GeneratePreMatchService } from './service/generatePre';
+import { SnowflakeIDGenerator } from '../id/main';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const preMatchRepository = isProduction
@@ -25,12 +27,33 @@ const teamRepository = isProduction
 
 const getMatchService = new GetMatchService(preMatchRepository, mainMatchRepository);
 const fetchTeamService = new FetchTeamService(teamRepository);
-const matchController = new MatchController(getMatchService, fetchTeamService);
+const idGenerator = new SnowflakeIDGenerator(1, () => BigInt(new Date().getTime()));
+const generatePreMatchService = new GeneratePreMatchService(
+  fetchTeamService,
+  idGenerator,
+  preMatchRepository
+);
+const matchController = new MatchController(
+  getMatchService,
+  fetchTeamService,
+  generatePreMatchService
+);
 
 export const matchHandlers = new OpenAPIHono();
 
 matchHandlers.openapi(GetMatchRoute, async (c) => {
   const res = await matchController.getAll();
+  if (Result.isErr(res)) {
+    return c.json({ description: res[1].message }, 400);
+  }
+
+  return c.json(res[1], 200);
+});
+
+matchHandlers.openapi(PostMatchGenerateRoute, async (c) => {
+  const { matchType, departmentType } = c.req.valid('param');
+
+  const res = await matchController.generateMatch(matchType, departmentType);
   if (Result.isErr(res)) {
     return c.json({ description: res[1].message }, 400);
   }

--- a/packages/kcms/src/match/routing.ts
+++ b/packages/kcms/src/match/routing.ts
@@ -111,7 +111,7 @@ export const GetMatchRunResultRoute = createRoute({
   },
 });
 
-export const GetMatchGenerateRoute = createRoute({
+export const PostMatchGenerateRoute = createRoute({
   method: 'post',
   path: '/match/{matchType}/{departmentType}/generate',
   request: { params: PostMatchGenerateParamsSchema },


### PR DESCRIPTION
close #439
## やったこと
- `POST /match/{matchType}/{departmentType}/generate`の実装
- Routeの命名を訂正