### PR TITLE
feat: 試合取得エンドポイントを実装

### DIFF
--- a/packages/kcms/src/match/adaptor/controller/match.ts
+++ b/packages/kcms/src/match/adaptor/controller/match.ts
@@ -1,9 +1,17 @@
 import { GetMatchService } from '../../service/get';
 import { z } from '@hono/zod-openapi';
-import { GetMatchResponseSchema, PreSchema } from '../validator/match';
+import {
+  GetMatchIdResponseSchema,
+  GetMatchResponseSchema,
+  PreSchema,
+  RunResultSchema,
+} from '../validator/match';
 import { Result } from '@mikuroxina/mini-fn';
 import { FetchTeamService } from '../../../team/service/get';
 import { TeamID } from '../../../team/models/team';
+import { MainMatchID } from '../../model/main';
+import { MatchType } from 'config';
+import { PreMatch, PreMatchID } from '../../model/pre';
 
 export class MatchController {
   constructor(
@@ -58,5 +66,48 @@ export class MatchController {
       // ToDo: 本戦試合を取得できるようにする
       main: [],
     });
+  }
+
+  async getMatchByID<T extends MatchType>(
+    matchType: T,
+    id: T extends 'pre' ? PreMatchID : MainMatchID
+  ): Promise<Result.Result<Error, z.infer<typeof GetMatchIdResponseSchema>>> {
+    if (matchType === 'pre') {
+      const res = await this.getMatchService.findById(id);
+      if (Result.isErr(res)) return res;
+      const match = Result.unwrap(res) as PreMatch;
+
+      const getTeam = async (
+        teamID: TeamID | undefined
+      ): Promise<{ id: string; teamName: string } | undefined> => {
+        if (!teamID) return undefined;
+        const teamRes = await this.fetchTeamService.findByID(teamID);
+        if (Result.isErr(teamRes)) return undefined;
+        const team = Result.unwrap(teamRes);
+        return {
+          id: team.getId(),
+          teamName: team.getTeamName(),
+        };
+      };
+
+      return Result.ok({
+        id: match.getId(),
+        matchCode: `${match.getCourseIndex()}-${match.getMatchIndex()}`,
+        departmentType: match.getDepartmentType(),
+        leftTeam: await getTeam(match.getTeamId1()),
+        rightTeam: await getTeam(match.getTeamId2()),
+        runResults: match.getRunResults().map(
+          (v): z.infer<typeof RunResultSchema> => ({
+            id: v.getId(),
+            teamID: v.getTeamId(),
+            points: v.getPoints(),
+            goalTimeSeconds: v.getGoalTimeSeconds(),
+            finishState: v.isGoal() ? 'goal' : 'finished',
+          })
+        ),
+      });
+    } else {
+      return Result.err(new Error('Not implemented'));
+    }
   }
 }

--- a/packages/kcms/src/match/adaptor/validator/match.ts
+++ b/packages/kcms/src/match/adaptor/validator/match.ts
@@ -12,7 +12,7 @@ const BriefTeamSchema = z
   })
   .optional();
 
-const RunResultSchema = z.object({
+export const RunResultSchema = z.object({
   id: z.string().openapi({ example: '60980640' }),
   teamID: z.string().openapi({ example: '45098607' }),
   points: z.number().openapi({ example: 4 }),

--- a/packages/kcms/src/match/main.ts
+++ b/packages/kcms/src/match/main.ts
@@ -9,8 +9,10 @@ import { FetchTeamService } from '../team/service/get';
 import { PrismaTeamRepository } from '../team/adaptor/repository/prismaRepository';
 import { DummyRepository } from '../team/adaptor/repository/dummyRepository';
 import { OpenAPIHono } from '@hono/zod-openapi';
-import { GetMatchRoute } from './routing';
+import { GetMatchIdRoute, GetMatchRoute } from './routing';
 import { Result } from '@mikuroxina/mini-fn';
+import { PreMatchID } from './model/pre';
+import { MainMatchID } from './model/main';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const preMatchRepository = isProduction
@@ -36,4 +38,16 @@ matchHandlers.openapi(GetMatchRoute, async (c) => {
   }
 
   return c.json(res[1], 200);
+});
+
+matchHandlers.openapi(GetMatchIdRoute, async (c) => {
+  const { matchType, matchID } = c.req.valid('param');
+
+  const res = await matchController.getMatchByID(matchType, matchID as MainMatchID | PreMatchID);
+  if (Result.isErr(res)) {
+    const error = Result.unwrapErr(res);
+    return c.json({ description: error.message }, 400);
+  }
+
+  return c.json(Result.unwrap(res), 200);
 });


### PR DESCRIPTION
close #438 

## やったこと
- 試合取得エンドポイント(Controller/Handler)を実装
  - 型推論が敗北したのでexportされていないスキーマをexportして使っています