### PR TITLE
feat: 本戦試合の手動生成ができるように

### DIFF
--- a/packages/kcms/src/match/adaptor/validator/match.ts
+++ b/packages/kcms/src/match/adaptor/validator/match.ts
@@ -115,6 +115,15 @@ export const PostMatchGenerateResponseSchema = z.union([
   ShortMainSchema.array(),
 ]);
 
+export const PostMatchGenerateManualParamsSchema = z.object({
+  departmentType: DepartmentTypeSchema,
+});
+export const PostMatchGenerateManualRequestSchema = z.object({
+  team1ID: z.string().openapi({ example: '45098607' }),
+  team2ID: z.string().openapi({ example: '2230392' }),
+});
+export const PostMatchGenerateManualResponseSchema = z.array(ShortMainSchema);
+
 export const PostMatchRunResultParamsSchema = z.object({
   matchType: MatchTypeSchema,
   matchID: z.string().openapi({ example: '320984' }),

--- a/packages/kcms/src/match/main.ts
+++ b/packages/kcms/src/match/main.ts
@@ -120,7 +120,6 @@ matchHandler.openapi(PostMatchGenerateRoute, async (c) => {
 
 /**
  * 本戦試合を手動で生成
- *
  */
 matchHandler.openapi(PostMatchGenerateManualRoute, async (c) => {
   const { departmentType } = c.req.valid('param');

--- a/packages/kcms/src/match/routing.ts
+++ b/packages/kcms/src/match/routing.ts
@@ -10,6 +10,9 @@ import {
   GetMatchTypeResponseSchema,
   GetRankingParamsSchema,
   GetRankingResponseSchema,
+  PostMatchGenerateManualParamsSchema,
+  PostMatchGenerateManualRequestSchema,
+  PostMatchGenerateManualResponseSchema,
   PostMatchGenerateParamsSchema,
   PostMatchGenerateResponseSchema,
   PostMatchRunResultParamsSchema,
@@ -120,6 +123,37 @@ export const PostMatchGenerateRoute = createRoute({
       content: {
         'application/json': {
           schema: PostMatchGenerateResponseSchema,
+        },
+      },
+      description: 'Generate match table',
+    },
+    400: {
+      content: {
+        'application/json': {
+          schema: CommonErrorSchema,
+        },
+      },
+      description: 'Common error',
+    },
+  },
+});
+
+export const PostMatchGenerateManualRoute = createRoute({
+  method: 'post',
+  path: '/match/main/{departmentType}/generate/manual',
+  request: {
+    params: PostMatchGenerateManualParamsSchema,
+    body: {
+      content: {
+        'application/json': { schema: PostMatchGenerateManualRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      content: {
+        'application/json': {
+          schema: PostMatchGenerateManualResponseSchema,
         },
       },
       description: 'Generate match table',


### PR DESCRIPTION
close #546 
## やったこと
- 本戦試合の手動生成ができるようになりました
- `POST /match/main/{departmentType}/generate/manual`が生えました