### PR TITLE
feat: (安来用)本戦試合のランキングを取得できる

### DIFF
--- a/packages/kcms/src/match/adaptor/controller/match.ts
+++ b/packages/kcms/src/match/adaptor/controller/match.ts
@@ -326,11 +326,11 @@ export class MatchController {
     matchType: MatchType,
     departmentType: DepartmentType
   ): Promise<Result.Result<Error, z.infer<typeof GetRankingResponseSchema>>> {
-    if (matchType !== 'pre') {
-      return Result.err(new Error('Not implemented'));
-    }
-
-    const rankingRes = await this.generateRankingService.generatePreMatchRanking(departmentType);
+    const generateRanking = {
+      pre: () => this.generateRankingService.generatePreMatchRanking(departmentType),
+      main: () => this.generateRankingService.generateMainMatchRanking(departmentType),
+    }[matchType];
+    const rankingRes = await generateRanking();
     if (Result.isErr(rankingRes)) return rankingRes;
     const ranking = Result.unwrap(rankingRes);
 

--- a/packages/kcms/src/match/main.ts
+++ b/packages/kcms/src/match/main.ts
@@ -64,7 +64,7 @@ const generatePreMatchService = new GeneratePreMatchService(
   idGenerator,
   preMatchRepository
 );
-const generateRankingService = new GenerateRankingService(preMatchRepository);
+const generateRankingService = new GenerateRankingService(preMatchRepository, mainMatchRepository);
 const fetchRunResultService = new FetchRunResultService(mainMatchRepository, preMatchRepository);
 const generateMainMatchService = new GenerateMainMatchService(mainMatchRepository, idGenerator);
 const matchController = new MatchController(

--- a/packages/kcms/src/match/service/generateRanking.test.ts
+++ b/packages/kcms/src/match/service/generateRanking.test.ts
@@ -17,7 +17,7 @@ describe('GenerateRankingService', () => {
     expect(Result.unwrap(res)).toHaveLength(11);
   });
 
-  it('(安来用)本戦: 部門ごとのランキングが生成できる', async () => {
+  it('本戦(安来用): 部門ごとのランキングが生成できる', async () => {
     const res = await service.generateMainMatchRanking('elementary');
     expect(Result.isErr(res)).toBe(false);
     expect(Result.unwrap(res)).toHaveLength(2);

--- a/packages/kcms/src/match/service/generateRanking.test.ts
+++ b/packages/kcms/src/match/service/generateRanking.test.ts
@@ -1,18 +1,26 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { describe, expect, it } from 'vitest';
 import { TeamID } from '../../team/models/team';
-import { testRankingPreMatchData } from '../../testData/match';
+import { testRankingMainMatchData, testRankingPreMatchData } from '../../testData/match';
+import { DummyMainMatchRepository } from '../adaptor/dummy/mainMatchRepository';
 import { DummyPreMatchRepository } from '../adaptor/dummy/preMatchRepository';
-import { GenerateRankingService } from './generateRanking';
+import { GenerateRankingService, RankingDatum } from './generateRanking';
 
 describe('GenerateRankingService', () => {
   const preMatchRepository = new DummyPreMatchRepository(testRankingPreMatchData);
-  const service = new GenerateRankingService(preMatchRepository);
+  const mainMatchRepository = new DummyMainMatchRepository(testRankingMainMatchData);
+  const service = new GenerateRankingService(preMatchRepository, mainMatchRepository);
 
-  it('部門ごとのランキングが正しく生成できる', async () => {
+  it('予選: 部門ごとのランキングが生成できる', async () => {
     const res = await service.generatePreMatchRanking('elementary');
     expect(Result.isErr(res)).toBe(false);
     expect(Result.unwrap(res)).toHaveLength(11);
+  });
+
+  it('(安来用)本戦: 部門ごとのランキングが生成できる', async () => {
+    const res = await service.generateMainMatchRanking('elementary');
+    expect(Result.isErr(res)).toBe(false);
+    expect(Result.unwrap(res)).toHaveLength(2);
   });
 
   it('予選: 同じ順位の場合、ゴールタイムでソートする', async () => {
@@ -31,6 +39,17 @@ describe('GenerateRankingService', () => {
     ];
 
     const res = await service.generatePreMatchRanking('elementary');
+    expect(Result.isErr(res)).toBe(false);
+    expect(Result.unwrap(res)).toStrictEqual(expected);
+  });
+
+  it('本戦(安来用): 同じ順位の場合、ゴールタイムでソートする', async () => {
+    const expected: RankingDatum[] = [
+      { rank: 1, teamID: '91' as TeamID, points: 17, goalTimeSeconds: 60 },
+      { rank: 2, teamID: '92' as TeamID, points: 17, goalTimeSeconds: 80 },
+    ];
+
+    const res = await service.generateMainMatchRanking('elementary');
     expect(Result.isErr(res)).toBe(false);
     expect(Result.unwrap(res)).toStrictEqual(expected);
   });

--- a/packages/kcms/src/match/service/generateRanking.ts
+++ b/packages/kcms/src/match/service/generateRanking.ts
@@ -1,7 +1,9 @@
 import { Result } from '@mikuroxina/mini-fn';
 import { DepartmentType } from 'config';
 import { TeamID } from '../../team/models/team';
-import { PreMatchRepository } from '../model/repository';
+import { MainMatch } from '../model/main';
+import { PreMatch } from '../model/pre';
+import { MainMatchRepository, PreMatchRepository } from '../model/repository';
 import { RunResult } from '../model/runResult';
 
 export interface RankingDatum {
@@ -12,7 +14,10 @@ export interface RankingDatum {
 }
 
 export class GenerateRankingService {
-  constructor(private readonly preMatchRepository: PreMatchRepository) {}
+  constructor(
+    private readonly preMatchRepository: PreMatchRepository,
+    private readonly mainMatchRepository: MainMatchRepository
+  ) {}
 
   async generatePreMatchRanking(
     departmentType: DepartmentType
@@ -25,6 +30,26 @@ export class GenerateRankingService {
       (match) => match.getDepartmentType() === departmentType
     );
 
+    return this.generateRanking(departmentMatches);
+  }
+
+  async generateMainMatchRanking(
+    departmentType: DepartmentType
+  ): Promise<Result.Result<Error, RankingDatum[]>> {
+    const matchesRes = await this.mainMatchRepository.findAll();
+    if (Result.isErr(matchesRes)) {
+      return matchesRes;
+    }
+    const departmentMatches = Result.unwrap(matchesRes).filter(
+      (match) => match.getDepartmentType() === departmentType
+    );
+
+    return this.generateRanking(departmentMatches);
+  }
+
+  private async generateRanking(
+    matches: (PreMatch | MainMatch)[]
+  ): Promise<Result.Result<Error, RankingDatum[]>> {
     // 各チームごとに走行結果を集める
     const teamRunResults = new Map<TeamID, RunResult[]>();
     const addRunResults = (teamID: TeamID | undefined, runResultSource: RunResult[]) => {
@@ -34,7 +59,7 @@ export class GenerateRankingService {
       const prev = teamRunResults.get(teamID) ?? [];
       teamRunResults.set(teamID, [...prev, ...runResults]);
     };
-    departmentMatches.forEach((match) => {
+    matches.forEach((match) => {
       const runResults = match.getRunResults();
       addRunResults(match.getTeamId1(), runResults);
       addRunResults(match.getTeamId2(), runResults);

--- a/packages/kcms/src/testData/match.ts
+++ b/packages/kcms/src/testData/match.ts
@@ -292,6 +292,11 @@ export const testRankingPreMatchData = [
     runResults: [],
   }),
 ];
+
+/**
+ * **安来用**本戦ランキング生成用の試合データ
+ * 本戦は本来トーナメントなので、この限りではない
+ */
 export const testRankingMainMatchData = [
   // ToDo: L/Rを入れるとL/Rを入れ替えたデータも作れるようにしたい
   MainMatch.new({
@@ -320,14 +325,14 @@ export const testRankingMainMatchData = [
       RunResult.new({
         id: '82' as RunResultID,
         teamID: '91' as TeamID,
-        points: 12,
+        points: 5,
         goalTimeSeconds: Infinity,
         finishState: 'FINISHED',
       }),
       RunResult.new({
         id: '83' as RunResultID,
         teamID: '92' as TeamID,
-        points: 1,
+        points: 7,
         goalTimeSeconds: 80,
         finishState: 'GOAL',
       }),


### PR DESCRIPTION
close #555 

- 1試合しかない(=2チームしかない)ことを前提に予選とアルゴリズムを共通化
- (TODO) 本大会に向け、将来的にはトーナメント用アルゴリズムに書き換える必要がある
- #571 のため現在実際の動作は確認できない