### PR TITLE
refactor: データフェッチをカスタムフック化

### DIFF
--- a/packages/kcmsf/src/components/GenerateMainMatchCard.tsx
+++ b/packages/kcmsf/src/components/GenerateMainMatchCard.tsx
@@ -8,10 +8,10 @@ import {
   Text,
   Title,
 } from "@mantine/core";
-import { useFetch } from "@mantine/hooks";
 import { IconRefresh } from "@tabler/icons-react";
 import { DepartmentType } from "config";
 import { useMemo } from "react";
+import { useFetch } from "../hooks/useFetch";
 import { RankingRecord } from "../types/contest";
 import { MainMatch } from "../types/match";
 import { GenerateMatchButton } from "./GenerateMatchButton";

--- a/packages/kcmsf/src/hooks/useFetch.ts
+++ b/packages/kcmsf/src/hooks/useFetch.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useState } from "react";
+
+type Option = {
+  auto?: boolean;
+};
+
+type UseFetch<Response extends Object> = {
+  data?: Response;
+  error?: Error;
+  loading?: boolean;
+  refetch: () => Promise<void>;
+};
+
+export const useFetch = <Response extends Object>(
+  query: string,
+  option: Option = {
+    auto: true,
+  }
+): UseFetch<Response> => {
+  const [data, setData] = useState<Response>();
+  const [error, setError] = useState<Error>();
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const refetch = useCallback(async () => {
+    try {
+      setLoading(true);
+      setData(undefined);
+      setError(undefined);
+
+      const res = await fetch(query);
+      const data = (await res.json()) as Response;
+
+      setLoading(false);
+      setData(data);
+    } catch (err) {
+      const error = new Error("Failed to fetch data", { cause: err });
+
+      setLoading(false);
+      setData(undefined);
+      setError(error);
+      throw error;
+    }
+  }, [query, setData, setError]);
+
+  useEffect(() => {
+    if (!option.auto) return;
+
+    refetch();
+  }, [option.auto, refetch]);
+
+  return { data, error, loading, refetch };
+};

--- a/packages/kcmsf/src/hooks/useFetch.ts
+++ b/packages/kcmsf/src/hooks/useFetch.ts
@@ -24,7 +24,6 @@ export const useFetch = <Response extends Object>(
   const refetch = useCallback(async () => {
     try {
       setLoading(true);
-      setData(undefined);
       setError(undefined);
 
       const res = await fetch(query);

--- a/packages/kcmsf/src/hooks/useFetch.ts
+++ b/packages/kcmsf/src/hooks/useFetch.ts
@@ -7,7 +7,7 @@ type Option = {
 type UseFetch<Response extends Object> = {
   data?: Response;
   error?: Error;
-  loading?: boolean;
+  loading: boolean;
   refetch: () => Promise<void>;
 };
 

--- a/packages/kcmsf/src/hooks/useFetch.ts
+++ b/packages/kcmsf/src/hooks/useFetch.ts
@@ -4,14 +4,14 @@ type Option = {
   auto?: boolean;
 };
 
-type UseFetch<Response extends Object> = {
+type UseFetch<Response extends object> = {
   data?: Response;
   error?: Error;
   loading: boolean;
   refetch: () => Promise<void>;
 };
 
-export const useFetch = <Response extends Object>(
+export const useFetch = <Response extends object>(
   query: string,
   option: Option = {
     auto: true,

--- a/packages/kcmsf/src/pages/matchList.tsx
+++ b/packages/kcmsf/src/pages/matchList.tsx
@@ -52,18 +52,20 @@ export const MatchList = () => {
     ).value
   );
 
-  const processedMatches = useMemo(
+  const processedMatches = useMemo<Match[]>(
     () =>
-      Cat.cat(matches)
-        .feed((matches) => matches?.[matchType])
-        .feed((matches) =>
-          selectedCourse == "all"
-            ? matches
-            : matches?.filter(
-                (match) =>
-                  Number(match.matchCode.split("-")[0]) == selectedCourse
-              )
-        ).value,
+      matches
+        ? Cat.cat(matches)
+            .feed((matches) => matches[matchType])
+            .feed((matches) =>
+              selectedCourse == "all"
+                ? matches
+                : matches.filter(
+                    (match) =>
+                      Number(match.matchCode.split("-")[0]) == selectedCourse
+                  )
+            ).value
+        : [],
     [matches, matchType, selectedCourse]
   );
 
@@ -94,7 +96,7 @@ export const MatchList = () => {
         matchType={matchType}
         setMatchType={setMatchType}
       />
-      {processedMatches && processedMatches.length > 0 && (
+      {processedMatches.length > 0 && (
         <>
           <Flex w="100%" justify="right">
             <CourseSelector courses={courses} selector={setSelectedCourse} />
@@ -126,39 +128,36 @@ export const MatchList = () => {
           </Button>
         </>
       )}
-      {processedMatches &&
-        processedMatches.length === 0 &&
-        !loading &&
-        !error && (
-          <>
-            <Text>現在試合はありません。</Text>
-            <GenerateMatchButton
-              generate={async () => {
-                await Promise.all(
-                  config.departmentTypes.map((departmentType) =>
-                    generateMatch(matchType, departmentType)
-                  )
-                );
-                refetch();
-              }}
-              modalTitle={`${config.match[matchType].name}試合表生成確認`}
-              modalDetail={
-                <>
-                  以下の試合表を生成します:
-                  <List withPadding>
-                    {config.departmentTypes.map((departmentType) => (
-                      <List.Item key={departmentType}>
-                        {config.match[matchType].name}&emsp;
-                        {config.department[departmentType].name}
-                      </List.Item>
-                    ))}
-                  </List>
-                </>
-              }
-              disabled={matchType != "pre"} // TODO: 本戦試合も生成できるように
-            />
-          </>
-        )}
+      {processedMatches.length === 0 && !loading && !error && (
+        <>
+          <Text>現在試合はありません。</Text>
+          <GenerateMatchButton
+            generate={async () => {
+              await Promise.all(
+                config.departmentTypes.map((departmentType) =>
+                  generateMatch(matchType, departmentType)
+                )
+              );
+              refetch();
+            }}
+            modalTitle={`${config.match[matchType].name}試合表生成確認`}
+            modalDetail={
+              <>
+                以下の試合表を生成します:
+                <List withPadding>
+                  {config.departmentTypes.map((departmentType) => (
+                    <List.Item key={departmentType}>
+                      {config.match[matchType].name}&emsp;
+                      {config.department[departmentType].name}
+                    </List.Item>
+                  ))}
+                </List>
+              </>
+            }
+            disabled={matchType != "pre"} // TODO: 本戦試合も生成できるように
+          />
+        </>
+      )}
     </Stack>
   );
 };

--- a/packages/kcmsf/src/pages/teams.tsx
+++ b/packages/kcmsf/src/pages/teams.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Filter } from "../components/Filter";
 import { LoaderButton } from "../components/LoaderButton";
 import { Order, Sort } from "../components/Sort";
+import { useFetch } from "../hooks/useFetch";
 import { GetTeamsResponse } from "../types/api/team";
 import { Team } from "../types/team";
 
@@ -32,6 +33,9 @@ type SortState = {
 type FilterState = Partial<Team>;
 
 export const Teams = () => {
+  const { data: teamsRes } = useFetch<GetTeamsResponse>(
+    `${import.meta.env.VITE_API_URL}/team`
+  );
   const [teams, setTeams] = useState<Map<string, Team>>();
   const [sortState, setSortState] = useState<SortState>({
     key: "entryCode",
@@ -152,22 +156,10 @@ export const Teams = () => {
   );
 
   useEffect(() => {
-    const getTeams = async () => {
-      const response = await fetch(`${import.meta.env.VITE_API_URL}/team`, {
-        method: "GET",
-      }).catch(() => undefined);
-      const teamResponse = (await response?.json()) as
-        | GetTeamsResponse
-        | undefined;
-
-      setTeams(
-        teamResponse
-          ? new Map(teamResponse.teams.map((team) => [team.id, team]))
-          : undefined
-      );
-    };
-    getTeams();
-  }, []);
+    setTeams(
+      teamsRes && new Map(teamsRes.teams.map((team) => [team.id, team]))
+    );
+  }, [setTeams, teamsRes]);
 
   return (
     <Flex direction="column" align="center" justify="center">

--- a/packages/kcmsf/tsconfig.json
+++ b/packages/kcmsf/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
close #613
close #117  

#### やったこと
- `useFetch`フックを作りました
- ロード時に発火していたfetchを`useFetch`に置き換えました

#### その他
- `Error.cause`が使いたかったためtargetをESNextに上げました