### PR TITLE
chore: tabler-iconsが動的importを行わないように設定

### DIFF
--- a/packages/kcmsf/vite.config.ts
+++ b/packages/kcmsf/vite.config.ts
@@ -4,4 +4,10 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      // 動的importを行わない
+      "@tabler/icons-react": "@tabler/icons-react/dist/esm/icons/index.mjs",
+    },
+  },
 });


### PR DESCRIPTION
cf. #470 
- バージョンを固定するためにはrenovateの設定を変更しなければならない
- renovateの設定を変更したくないため、パスエイリアスで動的importを行わないように変更した