### PR TITLE
fix: LabeledSegmentedControlが適切な幅で表示される

### DIFF
--- a/packages/kcmsf/src/components/LabeledSegmentedControl.tsx
+++ b/packages/kcmsf/src/components/LabeledSegmentedControl.tsx
@@ -1,7 +1,7 @@
 import {
-  Group,
   SegmentedControl,
   SegmentedControlItem,
+  Table,
   Text,
 } from "@mantine/core";
 
@@ -16,8 +16,17 @@ export const LabeledSegmentedControl = ({
   value: string;
   onChange: (value: string) => void;
 }) => (
-  <Group>
-    <Text c="dark">{label}</Text>
-    <SegmentedControl {...{ data, value, onChange }} w="7rem" />
-  </Group>
+  <Table.Tr>
+    <Table.Td>
+      <Text
+        c="dark"
+        children={label}
+        ta="right"
+        style={{ whiteSpace: "nowrap" }}
+      />
+    </Table.Td>
+    <Table.Td>
+      <SegmentedControl w="100%" {...{ data, value, onChange }} />
+    </Table.Td>
+  </Table.Tr>
 );

--- a/packages/kcmsf/src/components/LabeledSegmentedControls.tsx
+++ b/packages/kcmsf/src/components/LabeledSegmentedControls.tsx
@@ -1,0 +1,17 @@
+import { Table } from "@mantine/core";
+import React from "react";
+
+export const LabeledSegmentedControls = ({
+  children,
+}: {
+  children: React.ReactElement | React.ReactElement[];
+}) => (
+  <Table
+    withRowBorders={false}
+    w="fit-content"
+    horizontalSpacing="0.5rem"
+    verticalSpacing="0.2rem"
+  >
+    {children}
+  </Table>
+);

--- a/packages/kcmsf/src/pages/matchList.tsx
+++ b/packages/kcmsf/src/pages/matchList.tsx
@@ -17,6 +17,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { CourseSelector } from "../components/courseSelector";
 import { GenerateMatchButton } from "../components/GenerateMatchButton";
+import { LabeledSegmentedControls } from "../components/LabeledSegmentedControls";
 import {
   MatchStatusButton,
   StatusButtonProps,
@@ -92,10 +93,12 @@ export const MatchList = () => {
   return (
     <Stack justify="center" align="center" gap="md" w="fit-content">
       <Title m="1rem">試合表</Title>
-      <MatchSegmentedControl
-        matchType={matchType}
-        setMatchType={setMatchType}
-      />
+      <LabeledSegmentedControls>
+        <MatchSegmentedControl
+          matchType={matchType}
+          setMatchType={setMatchType}
+        />
+      </LabeledSegmentedControls>
       {processedMatches.length > 0 && (
         <>
           <Flex w="100%" justify="right">

--- a/packages/kcmsf/src/pages/ranking.tsx
+++ b/packages/kcmsf/src/pages/ranking.tsx
@@ -1,17 +1,11 @@
-import {
-  Checkbox,
-  Flex,
-  Stack,
-  Table,
-  Title,
-  useMantineTheme,
-} from "@mantine/core";
+import { Checkbox, Flex, Table, Title, useMantineTheme } from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { config, DepartmentType, MatchType } from "config";
 import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { DepartmentSegmentedControl } from "../components/DepartmentSegmentedControl";
 import { GenerateMainMatchCard } from "../components/GenerateMainMatchCard";
+import { LabeledSegmentedControls } from "../components/LabeledSegmentedControls";
 import { MatchSegmentedControl } from "../components/MatchTypeSegmentedControl";
 import { useFetch } from "../hooks/useFetch";
 import { useInterval } from "../hooks/useInterval";
@@ -69,7 +63,7 @@ export const Ranking = () => {
   return (
     <Flex direction="column" align="center" justify="center" gap="md">
       <Title mt="md">ランキング</Title>
-      <Stack gap={6} align="flex-end">
+      <LabeledSegmentedControls>
         <MatchSegmentedControl
           matchType={matchType}
           setMatchType={setMatchType}
@@ -78,7 +72,7 @@ export const Ranking = () => {
           departmentType={departmentType}
           setDepartmentType={setDepartmentType}
         />
-      </Stack>
+      </LabeledSegmentedControls>
       <Flex
         direction="row"
         align="stretch"


### PR DESCRIPTION
close #720 

-  レイアウトに内部的にTableを使用するようになりました
- 今後各種`***SegmentedControl`を使うときは`LabeledSegmentedControls`で包む必要があります