### PR TITLE
feat: フロントエンドに認証を追加

### DIFF
--- a/packages/kcms/README.md
+++ b/packages/kcms/README.md
@@ -19,10 +19,12 @@ Matz葉がにロボコン 大会運営支援ツール
 KCMS_ADMIN_USERNAME=<管理者ユーザ名>
 KCMS_ADMIN_PASSWORD=<管理者パスワード>
 KCMS_COOKIE_TOKEN_KEY=<Cookieのキー>
+KCMS_COOKIE_MAX_AGE=<Cookieの有効期間>
 KCMS_CLIENT_URL=<クライアントのproduction環境URL>
 ```
 
 - `<Cookieのキー>`は、特に理由がなければ`kcms-token`を推奨します。
+- `<Cookieの有効期間>`には、有効期間を数値(秒)で指定します。この期間が、ログイン状態が持続する時間になります。
 - `<クライアントのproduction環境URL>`は、ない場合は空欄で構いません。
 
 依存関係のインストール

--- a/packages/kcms/src/main.ts
+++ b/packages/kcms/src/main.ts
@@ -112,6 +112,8 @@ app.onError((err) => {
 
   return response;
 });
+
+app.get('/', (c) => c.json({ message: 'kcms is up' }));
 app.route('/', teamHandler);
 app.route('/', matchHandler);
 app.route('/', sponsorHandler);

--- a/packages/kcms/src/main.ts
+++ b/packages/kcms/src/main.ts
@@ -29,7 +29,7 @@ const EnvScheme = z.object({
 
 export type Env = z.infer<typeof EnvScheme>;
 
-const getEnv = <C extends Context = Context<{}, any, {}>>(c: C) => {
+const getEnv = <C extends Context = Parameters<typeof env>['0']>(c: C) => {
   const envSource = env<Env>(c);
   const envRes = EnvScheme.safeParse(envSource);
   if (!envRes.success) {

--- a/packages/kcms/src/main.ts
+++ b/packages/kcms/src/main.ts
@@ -71,17 +71,17 @@ app.get(
     const {
       NODE_ENV: nodeEnv,
       KCMS_COOKIE_TOKEN_KEY: cookieKey,
+      KCMS_COOKIE_MAX_AGE: cookieMaxAge,
     } = getEnv(c);
 
     const nowSeconds = Math.floor(Date.now() / 1000);
-    const ageSeconds = 60 * 5; // 5 minutes
 
     const token = await sign(
       {
         sub: 'admin',
         iss: 'kcms',
         iat: nowSeconds,
-        exp: nowSeconds + ageSeconds,
+        exp: nowSeconds + cookieMaxAge,
       },
       jwtSecret.privateKey,
       'ES256'
@@ -90,8 +90,8 @@ app.get(
       path: '/',
       httpOnly: true,
       secure: true,
-      maxAge: ageSeconds,
-      expires: new Date((nowSeconds + ageSeconds) * 1000),
+      maxAge: cookieMaxAge,
+      expires: new Date((nowSeconds + cookieMaxAge) * 1000),
       sameSite: 'strict',
       prefix: nodeEnv === 'production' ? 'host' : undefined,
     });

--- a/packages/kcms/src/main.ts
+++ b/packages/kcms/src/main.ts
@@ -84,18 +84,21 @@ app.get('/logout', async (c) => {
   deleteCookie(c, cookieKey);
   return c.newResponse(null, 200);
 });
-app.use('*', except(['/login', '/logout']), (c, next) => {
-  const { NODE_ENV: nodeEnv, KCMS_COOKIE_TOKEN_KEY: cookieKey } = env<Env>(c);
-  return jwt({
-    secret: jwtSecret.publicKey,
-    cookie: {
-      key: cookieKey,
-      secret: cookieSecret,
-      prefixOptions: nodeEnv === 'production' ? 'host' : undefined,
-    },
-    alg: 'ES256',
-  })(c, next);
-});
+app.use(
+  '*',
+  except(['/login', '/logout'], (c, next) => {
+    const { NODE_ENV: nodeEnv, KCMS_COOKIE_TOKEN_KEY: cookieKey } = env<Env>(c);
+    return jwt({
+      secret: jwtSecret.publicKey,
+      cookie: {
+        key: cookieKey,
+        secret: cookieSecret,
+        prefixOptions: nodeEnv === 'production' ? 'host' : undefined,
+      },
+      alg: 'ES256',
+    })(c, next);
+  })
+);
 
 app.route('/', teamHandler);
 app.route('/', matchHandler);

--- a/packages/kcmsf/src/App.tsx
+++ b/packages/kcmsf/src/App.tsx
@@ -5,13 +5,16 @@ import "@mantine/core/styles.css";
 import { Notifications } from "@mantine/notifications";
 import "@mantine/notifications/styles.css";
 import "./App.css";
+import { AuthProvider } from "./components/AuthProvider.tsx";
 import { router } from "./routes/router.tsx";
 
 const App = () => {
   return (
     <MantineProvider>
-      <Notifications />
-      <RouterProvider router={router} />
+      <AuthProvider>
+        <Notifications />
+        <RouterProvider router={router} />
+      </AuthProvider>
     </MantineProvider>
   );
 };

--- a/packages/kcmsf/src/components/AuthProvider.tsx
+++ b/packages/kcmsf/src/components/AuthProvider.tsx
@@ -1,0 +1,44 @@
+import { createContext, useCallback, useEffect, useState } from "react";
+import { Login } from "./Login";
+
+export const AuthContext = createContext<boolean | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [auth, setAuth] = useState<boolean>();
+  const check = useCallback(async (): Promise<boolean> => {
+    const checkRes = await fetch(`${import.meta.env.VITE_API_URL}/`, {
+      credentials: "include",
+    }).catch(() => undefined);
+    const res = checkRes?.ok ?? false;
+
+    if (!res) {
+      await fetch(`${import.meta.env.VITE_API_URL}/logout`);
+    }
+    setAuth(res);
+    return res;
+  }, []);
+  const login = useCallback(
+    async (username: string, password: string): Promise<boolean> => {
+      const loginRes = await fetch(`${import.meta.env.VITE_API_URL}/login`, {
+        credentials: "include",
+        headers: {
+          Authorization: `Basic ${btoa(`${username}:${password}`)}`,
+        },
+      }).catch(() => undefined);
+      if (!loginRes?.ok) return false;
+
+      return await check();
+    },
+    [check, setAuth]
+  );
+
+  useEffect(() => {
+    check();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={auth}>
+      {auth ? children : <Login auth={auth} login={login} />}
+    </AuthContext.Provider>
+  );
+};

--- a/packages/kcmsf/src/components/Login.tsx
+++ b/packages/kcmsf/src/components/Login.tsx
@@ -1,0 +1,96 @@
+import {
+  Button,
+  LoadingOverlay,
+  Paper,
+  PasswordInput,
+  Space,
+  Stack,
+  Text,
+  TextInput,
+  Title,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { IconLogin } from "@tabler/icons-react";
+import { useCallback, useState } from "react";
+
+export const Login = ({
+  auth,
+  login,
+}: {
+  auth: boolean | undefined;
+  login: (username: string, password: string) => Promise<boolean>;
+}) => {
+  const [loading, { open: startLoad, close: finishLoad }] = useDisclosure();
+  const [failed, setFailed] = useState<boolean>();
+  const onSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const username = event?.currentTarget.elements.namedItem("username");
+      const password = event?.currentTarget.elements.namedItem(
+        "password"
+      ) as HTMLInputElement;
+      if (
+        username instanceof HTMLInputElement &&
+        password instanceof HTMLInputElement
+      ) {
+        startLoad();
+        setFailed(undefined);
+
+        const res = await login(username.value, password.value);
+
+        finishLoad();
+        setFailed(!res);
+      }
+    },
+    [login]
+  );
+
+  return (
+    <Stack
+      w="100dvw"
+      miw="20rem"
+      h="100dvh"
+      align="center"
+      justify="center"
+      bg="gray.1"
+      style={{ boxSizing: "border-box" }}
+      px="xl"
+    >
+      <Paper shadow="sm" radius="md" p="xl" w="100%" maw="25rem" pos="relative">
+        <LoadingOverlay
+          overlayProps={{ radius: "md", blur: 1.5 }}
+          visible={auth == null}
+        />
+        <Title>kcmsx login</Title>
+        <Space h="md" />
+        <form onSubmit={onSubmit}>
+          <Stack ta="left" gap="xs">
+            <TextInput
+              name="username"
+              label="ユーザ名"
+              description="username"
+              placeholder="ユーザ名を入力"
+            />
+            <PasswordInput
+              name="password"
+              label="パスワード"
+              description="password"
+              placeholder="パスワードを入力"
+            />
+            <Text c="red" ta="center" h="lg">
+              {failed && "ログインに失敗しました"}
+            </Text>
+            <Button
+              type="submit"
+              loading={loading}
+              loaderProps={{ type: "dots" }}
+              leftSection={<IconLogin />}
+            >
+              ログイン
+            </Button>
+          </Stack>
+        </form>
+      </Paper>
+    </Stack>
+  );
+};

--- a/packages/kcmsf/src/components/match/matchSubmit.tsx
+++ b/packages/kcmsf/src/components/match/matchSubmit.tsx
@@ -64,6 +64,7 @@ export const MatchSubmit = ({
       {
         method: "post",
         body: JSON.stringify(runResults),
+        credentials: "include",
         headers: {
           "Content-Type": "application/json",
         },

--- a/packages/kcmsf/src/hooks/useAuth.ts
+++ b/packages/kcmsf/src/hooks/useAuth.ts
@@ -1,0 +1,4 @@
+import { useContext } from "react";
+import { AuthContext } from "../components/AuthProvider";
+
+export const useAuth = () => useContext(AuthContext);

--- a/packages/kcmsf/src/hooks/useFetch.ts
+++ b/packages/kcmsf/src/hooks/useFetch.ts
@@ -26,7 +26,9 @@ export const useFetch = <Response extends object>(
       setLoading(true);
       setError(undefined);
 
-      const res = await fetch(query);
+      const res = await fetch(query, {
+        credentials: "include",
+      });
       const data = (await res.json()) as Response;
 
       setLoading(false);

--- a/packages/kcmsf/src/hooks/useMatchInfo.ts
+++ b/packages/kcmsf/src/hooks/useMatchInfo.ts
@@ -15,7 +15,7 @@ export const useMatchInfo = (
     async (teamID: string): Promise<GetTeamResponse> => {
       const res = await fetch(
         `${import.meta.env.VITE_API_URL}/team/${teamID}`,
-        { method: "GET" }
+        { method: "GET", credentials: "include" }
       );
       return (await res.json()) as GetTeamResponse;
     },
@@ -27,7 +27,7 @@ export const useMatchInfo = (
 
     const res = await fetch(
       `${import.meta.env.VITE_API_URL}/match/${matchType}/${id}`,
-      { method: "GET" }
+      { method: "GET", credentials: "include" }
     );
     if (!res.ok) return;
 

--- a/packages/kcmsf/src/pages/matchList.tsx
+++ b/packages/kcmsf/src/pages/matchList.tsx
@@ -73,6 +73,7 @@ export const MatchList = () => {
         `${import.meta.env.VITE_API_URL}/match/${matchType}/${departmentType}/generate`,
         {
           method: "POST",
+          credentials: "include",
         }
       ).catch(() => undefined);
 

--- a/packages/kcmsf/src/pages/ranking.tsx
+++ b/packages/kcmsf/src/pages/ranking.tsx
@@ -52,6 +52,7 @@ export const Ranking = () => {
         {
           method: "POST",
           body: JSON.stringify(req),
+          credentials: "include",
           headers: {
             "Content-Type": "application/json",
           },

--- a/packages/kcmsf/src/pages/register.tsx
+++ b/packages/kcmsf/src/pages/register.tsx
@@ -28,6 +28,7 @@ export const Register = () => {
     };
     const res = await fetch(`${import.meta.env.VITE_API_URL}/team`, {
       method: "POST",
+      credentials: "include",
       headers: {
         "Content-Type": "application/json",
       },

--- a/packages/kcmsf/src/pages/registerBulk.tsx
+++ b/packages/kcmsf/src/pages/registerBulk.tsx
@@ -82,6 +82,7 @@ export const RegisterBulk = () => {
     );
     const res = await fetch(`${import.meta.env.VITE_API_URL}/team`, {
       method: "POST",
+      credentials: "include",
       headers: {
         "Content-Type": "application/json",
       },

--- a/packages/kcmsf/src/pages/teams.tsx
+++ b/packages/kcmsf/src/pages/teams.tsx
@@ -136,6 +136,7 @@ export const Teams = () => {
         `${import.meta.env.VITE_API_URL}/team/${teamID}/entry`,
         {
           method: isEnter ? "POST" : "DELETE",
+          credentials: "include",
         }
       );
       if (!response.ok) return;

--- a/packages/mock/src/main.ts
+++ b/packages/mock/src/main.ts
@@ -13,6 +13,7 @@ app.use(
       origin.match(/https:\/\/([a-zA-Z0-9\-]+\.)?kcmsx\.pages\.dev/) // Pagesのプレビュービルドのため
         ? origin
         : "http://localhost:5173",
+    credentials: true,
   })
 );
 


### PR DESCRIPTION
close #623 

- フロントエンドに認証を掛けた
- ブラウザのポップアップを回避するためバックエンドにも手を入れています
  - Basic Authの認証スキームを`KCMS-Basic`に差し替えています