### PR TITLE
chore: SetMainMatchWinnerServiceを実装

### DIFF
--- a/packages/kcms/src/match/adaptor/controller/match.ts
+++ b/packages/kcms/src/match/adaptor/controller/match.ts
@@ -11,6 +11,7 @@ import { GenerateMainMatchService } from '../../service/generateMain';
 import { GeneratePreMatchService } from '../../service/generatePre';
 import { GenerateRankingService } from '../../service/generateRanking';
 import { GetMatchService } from '../../service/get';
+import { SetMainMatchWinnerService } from '../../service/setMainWinner';
 import {
   GetMatchIDResponseSchema,
   GetMatchResponseSchema,
@@ -35,7 +36,8 @@ export class MatchController {
     private readonly generateRankingService: GenerateRankingService,
     private readonly fetchRunResultService: FetchRunResultService,
     private readonly generateMainMatchService: GenerateMainMatchService,
-    private readonly fetchTournamentService: FetchTournamentService
+    private readonly fetchTournamentService: FetchTournamentService,
+    private readonly setMainMatchWinnerService: SetMainMatchWinnerService
   ) {}
 
   async getAll(): Promise<Result.Result<Error, z.infer<typeof GetMatchResponseSchema>>> {
@@ -146,6 +148,16 @@ export class MatchController {
         winnerID: v.getWinnerID() ?? '',
       }))
     );
+  }
+
+  async setWinner(matchID: string, winnerID: string): Promise<Result.Result<Error, void>> {
+    const res = await this.setMainMatchWinnerService.handle(
+      matchID as MainMatchID,
+      winnerID as TeamID
+    );
+    if (Result.isErr(res)) return res;
+
+    return Result.ok(undefined);
   }
 
   async getMatchByID<T extends MatchType>(

--- a/packages/kcms/src/match/adaptor/validator/match.ts
+++ b/packages/kcms/src/match/adaptor/validator/match.ts
@@ -140,7 +140,7 @@ export const PostMatchRunResultParamsSchema = z.object({
   matchID: z.string().openapi({ example: '320984' }),
 });
 
-export const PostSetMatchWinnerParamsSchema = z.object({
+export const PostMatchWinnerIDParamsSchema = z.object({
   matchID: z.string().openapi({ example: '320984' }),
 });
 
@@ -170,6 +170,6 @@ export const GetTournamentParamsSchema = z.object({
 
 export const GetTournamentResponseSchema = TournamentSchema;
 
-export const PostWinnerIDRequestSchema = z.object({
+export const PostMatchWinnerIDRequestSchema = z.object({
   winnerID: z.string().openapi({ example: '31415926535' }),
 });

--- a/packages/kcms/src/match/adaptor/validator/match.ts
+++ b/packages/kcms/src/match/adaptor/validator/match.ts
@@ -140,6 +140,10 @@ export const PostMatchRunResultParamsSchema = z.object({
   matchID: z.string().openapi({ example: '320984' }),
 });
 
+export const PostSetMatchWinnerParamsSchema = z.object({
+  matchID: z.string().openapi({ example: '320984' }),
+});
+
 export const PostMatchRunResultRequestSchema = z
   .array(RunResultSchema.omit({ id: true }))
   .max(4)
@@ -165,3 +169,7 @@ export const GetTournamentParamsSchema = z.object({
 });
 
 export const GetTournamentResponseSchema = TournamentSchema;
+
+export const PostWinnerIDRequestSchema = z.object({
+  winnerID: z.string().openapi({ example: '31415926535' }),
+});

--- a/packages/kcms/src/match/main.ts
+++ b/packages/kcms/src/match/main.ts
@@ -25,7 +25,7 @@ import {
   PostMatchGenerateManualRoute,
   PostMatchGenerateRoute,
   PostMatchRunResultRoute,
-  PostMatchSetWinnerIDRoute,
+  PostMatchWinnerIDRoute,
 } from './routing';
 import { CreateRunResultService } from './service/createRunResult';
 import { FetchRunResultService } from './service/fetchRunResult';
@@ -136,7 +136,7 @@ matchHandler.openapi(PostMatchGenerateManualRoute, async (c) => {
   return c.json(res[1], 200);
 });
 
-matchHandler.openapi(PostMatchSetWinnerIDRoute, async (c) => {
+matchHandler.openapi(PostMatchWinnerIDRoute, async (c) => {
   const { matchID } = c.req.valid('param');
   const req = c.req.valid('json');
 

--- a/packages/kcms/src/match/main.ts
+++ b/packages/kcms/src/match/main.ts
@@ -25,6 +25,7 @@ import {
   PostMatchGenerateManualRoute,
   PostMatchGenerateRoute,
   PostMatchRunResultRoute,
+  PostMatchSetWinnerIDRoute,
 } from './routing';
 import { CreateRunResultService } from './service/createRunResult';
 import { FetchRunResultService } from './service/fetchRunResult';
@@ -33,6 +34,7 @@ import { GenerateMainMatchService } from './service/generateMain';
 import { GeneratePreMatchService } from './service/generatePre';
 import { GenerateRankingService } from './service/generateRanking';
 import { GetMatchService } from './service/get';
+import { SetMainMatchWinnerService } from './service/setMainWinner';
 import { upcase } from './utility/upcase';
 
 // Repositories
@@ -65,6 +67,7 @@ const generateMainMatchService = new GenerateMainMatchService(
   config.match.main.requiredTeams
 );
 const fetchTournamentService = new FetchTournamentService(getMatchService);
+const setWinnerService = new SetMainMatchWinnerService(mainMatchRepository);
 const matchController = new MatchController(
   getMatchService,
   fetchTeamService,
@@ -72,7 +75,8 @@ const matchController = new MatchController(
   generateRankingService,
   fetchRunResultService,
   generateMainMatchService,
-  fetchTournamentService
+  fetchTournamentService,
+  setWinnerService
 );
 export const matchHandler = new OpenAPIHono();
 
@@ -130,6 +134,18 @@ matchHandler.openapi(PostMatchGenerateManualRoute, async (c) => {
   }
 
   return c.json(res[1], 200);
+});
+
+matchHandler.openapi(PostMatchSetWinnerIDRoute, async (c) => {
+  const { matchID } = c.req.valid('param');
+  const req = c.req.valid('json');
+
+  const res = await matchController.setWinner(matchID, req.winnerID);
+  if (Result.isErr(res)) {
+    return c.json({ description: res[1].message }, 400);
+  }
+
+  return c.json(200);
 });
 
 matchHandler.openapi(GetMatchIDRoute, async (c) => {

--- a/packages/kcms/src/match/model/main.test.ts
+++ b/packages/kcms/src/match/model/main.test.ts
@@ -241,4 +241,60 @@ describe('MainMatch', () => {
       new Error('WinnerID must be teamID1 or teamID2')
     );
   });
+
+  it('チームは上書き設定できない', () => {
+    const args: CreateMainMatchArgs = {
+      id: '1' as MainMatchID,
+      courseIndex: 1,
+      matchIndex: 1,
+      departmentType: config.departmentTypes[0],
+      teamID1: '2' as TeamID,
+      teamID2: '3' as TeamID,
+      runResults: [...Array(4)].map((_, i) => {
+        return RunResult.new({
+          id: String(i) as RunResultID,
+          goalTimeSeconds: i * 10,
+          points: 10 + i,
+          teamID: i % 2 == 0 ? ('2' as TeamID) : ('3' as TeamID),
+          finishState: 'FINISHED',
+        });
+      }),
+      parentMatchID: '10' as MainMatchID,
+      childMatches: undefined,
+    };
+    const mainMatch = MainMatch.new(args);
+
+    expect(() => mainMatch.setTeams('4' as TeamID, '5' as TeamID)).toThrowError(
+      new Error('Teams are already set')
+    );
+  });
+
+  it('チームを設定できる', () => {
+    const args: CreateMainMatchArgs = {
+      id: '1' as MainMatchID,
+      courseIndex: 1,
+      matchIndex: 1,
+      departmentType: config.departmentTypes[0],
+      teamID1: undefined,
+      teamID2: undefined,
+      runResults: [...Array(4)].map((_, i) => {
+        return RunResult.new({
+          id: String(i) as RunResultID,
+          goalTimeSeconds: i * 10,
+          points: 10 + i,
+          teamID: i % 2 == 0 ? ('2' as TeamID) : ('3' as TeamID),
+          finishState: 'FINISHED',
+        });
+      }),
+      parentMatchID: '10' as MainMatchID,
+      childMatches: undefined,
+    };
+    const mainMatch = MainMatch.new(args);
+
+    expect(() => mainMatch.setTeams('4' as TeamID, '5' as TeamID)).not.toThrowError(
+      new Error('Teams are already set')
+    );
+    expect(mainMatch.getTeamID1()).toStrictEqual('4' as TeamID);
+    expect(mainMatch.getTeamID2()).toStrictEqual('5' as TeamID);
+  });
 });

--- a/packages/kcms/src/match/model/main.test.ts
+++ b/packages/kcms/src/match/model/main.test.ts
@@ -277,15 +277,7 @@ describe('MainMatch', () => {
       departmentType: config.departmentTypes[0],
       teamID1: undefined,
       teamID2: undefined,
-      runResults: [...Array(4)].map((_, i) => {
-        return RunResult.new({
-          id: String(i) as RunResultID,
-          goalTimeSeconds: i * 10,
-          points: 10 + i,
-          teamID: i % 2 == 0 ? ('2' as TeamID) : ('3' as TeamID),
-          finishState: 'FINISHED',
-        });
-      }),
+      runResults: [],
       parentMatchID: '10' as MainMatchID,
       childMatches: undefined,
     };

--- a/packages/kcms/src/match/model/main.ts
+++ b/packages/kcms/src/match/model/main.ts
@@ -113,6 +113,15 @@ export class MainMatch {
     this.teamID2 = teamID;
   }
 
+  setTeams(teamID1: TeamID, teamID2: TeamID) {
+    // すでにチームがセットされている場合はエラー
+    if (this.teamID1 || this.teamID2) {
+      throw new Error('Teams are already set');
+    }
+    this.teamID1 = teamID1;
+    this.teamID2 = teamID2;
+  }
+
   getWinnerID(): TeamID | undefined {
     return this.winnerID;
   }

--- a/packages/kcms/src/match/routing.ts
+++ b/packages/kcms/src/match/routing.ts
@@ -19,6 +19,7 @@ import {
   PostMatchGenerateResponseSchema,
   PostMatchRunResultParamsSchema,
   PostMatchRunResultRequestSchema,
+  PostSetMatchWinnerParamsSchema,
 } from '../match/adaptor/validator/match';
 
 export const GetMatchRoute = createRoute({
@@ -159,6 +160,32 @@ export const PostMatchGenerateManualRoute = createRoute({
         },
       },
       description: 'Generate match table',
+    },
+    400: {
+      content: {
+        'application/json': {
+          schema: CommonErrorSchema,
+        },
+      },
+      description: 'Common error',
+    },
+  },
+});
+
+export const PostMatchSetWinnerIDRoute = createRoute({
+  method: 'post',
+  path: '/math/main/{matchID}/winner',
+  request: {
+    params: PostSetMatchWinnerParamsSchema,
+    body: {
+      content: {
+        'application/json': { schema: PostWinnerIDRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: 'OK',
     },
     400: {
       content: {

--- a/packages/kcms/src/match/routing.ts
+++ b/packages/kcms/src/match/routing.ts
@@ -19,8 +19,8 @@ import {
   PostMatchGenerateResponseSchema,
   PostMatchRunResultParamsSchema,
   PostMatchRunResultRequestSchema,
-  PostSetMatchWinnerParamsSchema,
-  PostWinnerIDRequestSchema,
+  PostMatchWinnerIDParamsSchema,
+  PostMatchWinnerIDRequestSchema,
 } from '../match/adaptor/validator/match';
 
 export const GetMatchRoute = createRoute({
@@ -173,14 +173,14 @@ export const PostMatchGenerateManualRoute = createRoute({
   },
 });
 
-export const PostMatchSetWinnerIDRoute = createRoute({
+export const PostMatchWinnerIDRoute = createRoute({
   method: 'post',
   path: '/match/main/{matchID}/winner',
   request: {
-    params: PostSetMatchWinnerParamsSchema,
+    params: PostMatchWinnerIDParamsSchema,
     body: {
       content: {
-        'application/json': { schema: PostWinnerIDRequestSchema },
+        'application/json': { schema: PostMatchWinnerIDRequestSchema },
       },
     },
   },

--- a/packages/kcms/src/match/routing.ts
+++ b/packages/kcms/src/match/routing.ts
@@ -20,6 +20,7 @@ import {
   PostMatchRunResultParamsSchema,
   PostMatchRunResultRequestSchema,
   PostSetMatchWinnerParamsSchema,
+  PostWinnerIDRequestSchema,
 } from '../match/adaptor/validator/match';
 
 export const GetMatchRoute = createRoute({

--- a/packages/kcms/src/match/routing.ts
+++ b/packages/kcms/src/match/routing.ts
@@ -175,7 +175,7 @@ export const PostMatchGenerateManualRoute = createRoute({
 
 export const PostMatchSetWinnerIDRoute = createRoute({
   method: 'post',
-  path: '/math/main/{matchID}/winner',
+  path: '/match/main/{matchID}/winner',
   request: {
     params: PostSetMatchWinnerParamsSchema,
     body: {

--- a/packages/kcms/src/match/service/setMainWinner.test.ts
+++ b/packages/kcms/src/match/service/setMainWinner.test.ts
@@ -1,0 +1,237 @@
+import { Option, Result } from '@mikuroxina/mini-fn';
+import { config } from 'config';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { TeamID } from '../../team/models/team';
+import { DummyMainMatchRepository } from '../adaptor/dummy/mainMatchRepository';
+import { MainMatch, MainMatchID } from '../model/main';
+import { RunResult, RunResultID } from '../model/runResult';
+import { SetMainMatchWinnerService } from './setMainWinner';
+
+describe('SetMainMatchWinnerService', () => {
+  const parentMatch = MainMatch.new({
+    id: '103' as MainMatchID,
+    courseIndex: 1,
+    matchIndex: 2,
+    departmentType: config.departmentTypes[0],
+    teamID1: undefined,
+    teamID2: undefined,
+    winnerID: undefined,
+    runResults: [],
+    parentMatchID: undefined,
+    childMatches: undefined,
+  });
+  const childMatch1 = MainMatch.new({
+    id: '101' as MainMatchID,
+    courseIndex: 1,
+    matchIndex: 2,
+    departmentType: config.departmentTypes[0],
+    teamID1: '1' as TeamID,
+    teamID2: '2' as TeamID,
+    winnerID: undefined,
+    runResults: [
+      RunResult.new({
+        id: '80' as RunResultID,
+        teamID: '1' as TeamID,
+        points: 12,
+        goalTimeSeconds: 60,
+        finishState: 'GOAL',
+      }),
+      RunResult.new({
+        id: '81' as RunResultID,
+        teamID: '2' as TeamID,
+        points: 10,
+        goalTimeSeconds: Infinity,
+        finishState: 'FINISHED',
+      }),
+      RunResult.new({
+        id: '82' as RunResultID,
+        teamID: '1' as TeamID,
+        points: 5,
+        goalTimeSeconds: Infinity,
+        finishState: 'FINISHED',
+      }),
+      RunResult.new({
+        id: '83' as RunResultID,
+        teamID: '2' as TeamID,
+        points: 7,
+        goalTimeSeconds: 80,
+        finishState: 'GOAL',
+      }),
+    ],
+    parentMatchID: parentMatch.getID(),
+    childMatches: undefined,
+  });
+
+  // 未終了のmatch1
+  const notFinishedChildMatch1 = MainMatch.new({
+    id: '101' as MainMatchID,
+    courseIndex: 1,
+    matchIndex: 2,
+    departmentType: config.departmentTypes[0],
+    teamID1: '1' as TeamID,
+    teamID2: '2' as TeamID,
+    winnerID: undefined,
+    runResults: [
+      RunResult.new({
+        id: '80' as RunResultID,
+        teamID: '1' as TeamID,
+        points: 12,
+        goalTimeSeconds: 60,
+        finishState: 'GOAL',
+      }),
+      RunResult.new({
+        id: '81' as RunResultID,
+        teamID: '2' as TeamID,
+        points: 10,
+        goalTimeSeconds: Infinity,
+        finishState: 'FINISHED',
+      }),
+    ],
+    parentMatchID: parentMatch.getID(),
+    childMatches: undefined,
+  });
+  const childMatch2 = MainMatch.new({
+    id: '102' as MainMatchID,
+    courseIndex: 1,
+    matchIndex: 2,
+    departmentType: config.departmentTypes[0],
+    teamID1: '10' as TeamID,
+    teamID2: '20' as TeamID,
+    winnerID: '10' as TeamID,
+    runResults: [
+      RunResult.new({
+        id: '180' as RunResultID,
+        teamID: '10' as TeamID,
+        points: 12,
+        goalTimeSeconds: 60,
+        finishState: 'GOAL',
+      }),
+      RunResult.new({
+        id: '181' as RunResultID,
+        teamID: '20' as TeamID,
+        points: 10,
+        goalTimeSeconds: Infinity,
+        finishState: 'FINISHED',
+      }),
+      RunResult.new({
+        id: '182' as RunResultID,
+        teamID: '10' as TeamID,
+        points: 5,
+        goalTimeSeconds: Infinity,
+        finishState: 'FINISHED',
+      }),
+      RunResult.new({
+        id: '183' as RunResultID,
+        teamID: '20' as TeamID,
+        points: 7,
+        goalTimeSeconds: 80,
+        finishState: 'GOAL',
+      }),
+    ],
+    parentMatchID: parentMatch.getID(),
+    childMatches: undefined,
+  });
+  // 未終了のmatch2
+  const notFinishedChildMatch2 = MainMatch.new({
+    id: '1020' as MainMatchID,
+    courseIndex: 1,
+    matchIndex: 2,
+    departmentType: config.departmentTypes[0],
+    teamID1: '10' as TeamID,
+    teamID2: '20' as TeamID,
+    winnerID: undefined,
+    runResults: [
+      RunResult.new({
+        id: '180' as RunResultID,
+        teamID: '10' as TeamID,
+        points: 12,
+        goalTimeSeconds: 60,
+        finishState: 'GOAL',
+      }),
+      RunResult.new({
+        id: '181' as RunResultID,
+        teamID: '20' as TeamID,
+        points: 10,
+        goalTimeSeconds: Infinity,
+        finishState: 'FINISHED',
+      }),
+    ],
+    parentMatchID: parentMatch.getID(),
+    childMatches: undefined,
+  });
+  const mainMatchRepository = new DummyMainMatchRepository([childMatch1, childMatch2, parentMatch]);
+  const service = new SetMainMatchWinnerService(mainMatchRepository);
+
+  beforeEach(() => {
+    // クリーンアップ
+    parentMatch.setChildMatches({ match1: childMatch1, match2: childMatch2 });
+    mainMatchRepository.clear([childMatch1, childMatch2, parentMatch]);
+  });
+
+  it('試合に勝者を設定できる', async () => {
+    const res = await service.handle(childMatch1.getID(), childMatch1.getTeamID1()!);
+    expect(res).toEqual(Result.ok(undefined));
+
+    // 試合の勝者が設定されていること
+    const matchRes = await mainMatchRepository.findByID(childMatch1.getID());
+    expect(Option.isNone(matchRes)).toBe(false);
+    const match = Option.unwrap(matchRes);
+    expect(match.getWinnerID()).toBe(childMatch1.getTeamID1());
+
+    // もう一方も終了しているなら親チームの情報も同時に更新されていること
+    const parentRes = await mainMatchRepository.findByID(parentMatch.getID());
+    expect(Option.isNone(parentRes)).toBe(false);
+    const parent = Option.unwrap(parentRes);
+    expect(parent.getTeamID1()).toBe(childMatch1.getTeamID1());
+    expect(parent.getTeamID2()).toBe(childMatch2.getTeamID1());
+  });
+
+  it('試合が終了していない時は設定できない', async () => {
+    mainMatchRepository.clear([notFinishedChildMatch1, childMatch2, parentMatch]);
+    const res = await service.handle(
+      notFinishedChildMatch1.getID(),
+      notFinishedChildMatch1.getTeamID1()!
+    );
+
+    expect(res).toEqual(Result.err(new Error('This match is not finished')));
+  });
+
+  it('同じparentを持つ試合の勝者が設定されている場合は、設定と同時にparentのチームも更新される', async () => {
+    await service.handle(childMatch1.getID(), childMatch1.getTeamID1()!);
+
+    const parentRes = await mainMatchRepository.findByID(parentMatch.getID());
+    expect(Option.isNone(parentRes)).toBe(false);
+    const parent = Option.unwrap(parentRes);
+
+    expect(parent.getTeamID1()).toBe(childMatch1.getTeamID1());
+    expect(parent.getTeamID2()).toBe(childMatch2.getTeamID1());
+  });
+
+  it('同じparentを持つ試合の勝者が設定されていない場合はparentのチームは更新されない', async () => {
+    mainMatchRepository.clear([
+      childMatch1,
+      notFinishedChildMatch2,
+      MainMatch.new({
+        id: '103' as MainMatchID,
+        courseIndex: 1,
+        matchIndex: 2,
+        departmentType: config.departmentTypes[0],
+        teamID1: undefined,
+        teamID2: undefined,
+        winnerID: undefined,
+        runResults: [],
+        parentMatchID: undefined,
+        childMatches: { match1: childMatch1, match2: notFinishedChildMatch2 },
+      }),
+    ]);
+
+    await service.handle(childMatch1.getID(), childMatch1.getTeamID1()!);
+
+    const parentRes = await mainMatchRepository.findByID(parentMatch.getID());
+    expect(Option.isNone(parentRes)).toBe(false);
+    const parent = Option.unwrap(parentRes);
+
+    expect(parent.getTeamID1()).toBe(undefined);
+    expect(parent.getTeamID2()).toBe(undefined);
+  });
+});

--- a/packages/kcms/src/match/service/setMainWinner.ts
+++ b/packages/kcms/src/match/service/setMainWinner.ts
@@ -1,0 +1,65 @@
+import { Option, Result } from '@mikuroxina/mini-fn';
+import { TeamID } from '../../team/models/team';
+import { MainMatchID } from '../model/main';
+import { MainMatchRepository } from '../model/repository';
+
+export class SetMainMatchWinnerService {
+  constructor(private readonly mainMatchRepository: MainMatchRepository) {}
+
+  async handle(matchID: MainMatchID, winnerID: TeamID): Promise<Result.Result<Error, void>> {
+    const matchRes = await this.mainMatchRepository.findByID(matchID);
+    if (Option.isNone(matchRes)) {
+      return Result.err(new Error('Match not found'));
+    }
+    const match = Option.unwrap(matchRes);
+
+    try {
+      match.setWinnerID(winnerID);
+    } catch (e) {
+      return Result.err(e as unknown as Error);
+    }
+
+    const matchUpdateRes = await this.mainMatchRepository.update(match);
+    if (Result.isErr(matchUpdateRes)) {
+      return matchUpdateRes;
+    }
+
+    // note: 決勝なら親がいないため、ここで終了
+    const parentID = match.getParentID();
+    if (!parentID) {
+      return Result.ok(undefined);
+    }
+
+    // 親の試合を取得し、もう片方の試合情報を取り出す
+    const parentMatchRes = await this.mainMatchRepository.findByID(parentID);
+    if (Option.isNone(parentMatchRes)) {
+      return Result.err(new Error('Parent match not found'));
+    }
+    const parentMatch = Option.unwrap(parentMatchRes);
+
+    const childMatches = parentMatch.getChildMatches();
+    // none: 親の子は必ず存在するのでnon-null assertionを使う
+    const otherMatch =
+      childMatches!.match1.getID() === matchID ? childMatches!.match2 : childMatches!.match1;
+
+    // もう片方の試合が終了していない場合は終了
+    const otherWinnerID = otherMatch.getWinnerID();
+    if (!otherWinnerID) {
+      return Result.ok(undefined);
+    }
+
+    // もう片方も終わっているなら、親試合のチームにそれぞれの勝者を設定する
+    try {
+      parentMatch.setTeams(winnerID, otherWinnerID);
+    } catch (e) {
+      return Result.err(e as unknown as Error);
+    }
+
+    const parentMatchUpdateRes = await this.mainMatchRepository.update(parentMatch);
+    if (Result.isErr(parentMatchUpdateRes)) {
+      return parentMatchUpdateRes;
+    }
+
+    return Result.ok(undefined);
+  }
+}

--- a/packages/kcms/src/match/service/setMainWinner.ts
+++ b/packages/kcms/src/match/service/setMainWinner.ts
@@ -50,7 +50,12 @@ export class SetMainMatchWinnerService {
 
     // もう片方も終わっているなら、親試合のチームにそれぞれの勝者を設定する
     try {
-      parentMatch.setTeams(winnerID, otherWinnerID);
+      // 自分が左側の場合
+      if (matchID === childMatches!.match1.getID()) {
+        parentMatch.setTeams(winnerID, otherWinnerID);
+      } else {
+        parentMatch.setTeams(otherWinnerID, winnerID);
+      }
     } catch (e) {
       return Result.err(e as unknown as Error);
     }

--- a/packages/kcms/src/match/service/setMainWinner.ts
+++ b/packages/kcms/src/match/service/setMainWinner.ts
@@ -16,7 +16,7 @@ export class SetMainMatchWinnerService {
     try {
       match.setWinnerID(winnerID);
     } catch (e) {
-      return Result.err(e as unknown as Error);
+      return Result.err(e as Error);
     }
 
     const matchUpdateRes = await this.mainMatchRepository.update(match);
@@ -57,7 +57,7 @@ export class SetMainMatchWinnerService {
         parentMatch.setTeams(otherWinnerID, winnerID);
       }
     } catch (e) {
-      return Result.err(e as unknown as Error);
+      return Result.err(e as Error);
     }
 
     const parentMatchUpdateRes = await this.mainMatchRepository.update(parentMatch);

--- a/packages/kcms/src/match/service/setMainWinner.ts
+++ b/packages/kcms/src/match/service/setMainWinner.ts
@@ -40,7 +40,9 @@ export class SetMainMatchWinnerService {
     const parentChildMatches = parentMatch.getChildMatches()!;
     // note: 親の子は必ず存在するのでnon-null assertionを使う
     const otherMatch =
-      parentChildMatches.match1.getID() === matchID ? parentChildMatches.match2 : parentChildMatches.match1;
+      parentChildMatches.match1.getID() === matchID
+        ? parentChildMatches.match2
+        : parentChildMatches.match1;
 
     // もう片方の試合が終了していない場合は終了
     const otherWinnerID = otherMatch.getWinnerID();

--- a/packages/kcms/src/match/service/setMainWinner.ts
+++ b/packages/kcms/src/match/service/setMainWinner.ts
@@ -37,10 +37,10 @@ export class SetMainMatchWinnerService {
     }
     const parentMatch = Option.unwrap(parentMatchRes);
 
-    const childMatches = parentMatch.getChildMatches();
-    // none: 親の子は必ず存在するのでnon-null assertionを使う
+    const parentChildMatches = parentMatch.getChildMatches()!;
+    // note: 親の子は必ず存在するのでnon-null assertionを使う
     const otherMatch =
-      childMatches!.match1.getID() === matchID ? childMatches!.match2 : childMatches!.match1;
+      parentChildMatches.match1.getID() === matchID ? parentChildMatches.match2 : parentChildMatches.match1;
 
     // もう片方の試合が終了していない場合は終了
     const otherWinnerID = otherMatch.getWinnerID();
@@ -51,7 +51,7 @@ export class SetMainMatchWinnerService {
     // もう片方も終わっているなら、親試合のチームにそれぞれの勝者を設定する
     try {
       // 自分が左側の場合
-      if (matchID === childMatches!.match1.getID()) {
+      if (matchID === parentChildMatches.match1.getID()) {
         parentMatch.setTeams(winnerID, otherWinnerID);
       } else {
         parentMatch.setTeams(otherWinnerID, winnerID);


### PR DESCRIPTION
## やったこと
- MainMatchモデルにsetTeams(teamID1, teamID2)を追加
- SetMainMatchWinnerServiceを実装
  - 終了した試合にwinnerIDを設定する
  - 同じ親を持つもう一方の試合が終了している場合は、親試合のチームを設定する