### PR TITLE
chore(ci): `packageManager`フィールドにハッシュ値を含め、最新のcorepackを使用する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - run: npm i -g --force corepack
+      - run: pnpm i -g --force corepack
       - run: corepack enable
       - name: Setup Nodejs v20
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - run: pnpm i -g --force corepack
+      - run: npm i -g --force corepack
       - run: corepack enable
       - name: Setup Nodejs v20
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - run: npm i -g --force corepack
       - run: corepack enable
       - name: Setup Nodejs v20
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
   "workspaces": [
     "packages/*"
   ],
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@9.15.4+sha256.9bee59c7313a216722c079c1e22160dea7f88df4e0c3450b1d7b01b882336c6a"
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,5 +26,6 @@
     "prettier": "^3.3.3",
     "prettier-plugin-organize-imports": "^4.0.0",
     "vitest": "^2.0.0"
-  }
+  },
+  "packageManager": "pnpm@9.15.4+sha256.9bee59c7313a216722c079c1e22160dea7f88df4e0c3450b1d7b01b882336c6a"
 }

--- a/packages/kcms/package.json
+++ b/packages/kcms/package.json
@@ -47,5 +47,6 @@
     "prisma": "^5.20.0",
     "tsx": "^4.6.2",
     "vitest": "^2.0.0"
-  }
+  },
+  "packageManager": "pnpm@9.15.4+sha256.9bee59c7313a216722c079c1e22160dea7f88df4e0c3450b1d7b01b882336c6a"
 }

--- a/packages/kcmsf/package.json
+++ b/packages/kcmsf/package.json
@@ -59,5 +59,6 @@
     "typescript": "^5.3.3",
     "vite": "^6.0.0",
     "vitest": "^2.0.0"
-  }
+  },
+  "packageManager": "pnpm@9.15.4"
 }

--- a/packages/kcmsf/package.json
+++ b/packages/kcmsf/package.json
@@ -60,5 +60,5 @@
     "vite": "^6.0.0",
     "vitest": "^2.0.0"
   },
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@9.15.4+sha256.9bee59c7313a216722c079c1e22160dea7f88df4e0c3450b1d7b01b882336c6a"
 }

--- a/packages/kcmsf/package.json
+++ b/packages/kcmsf/package.json
@@ -59,6 +59,5 @@
     "typescript": "^5.3.3",
     "vite": "^6.0.0",
     "vitest": "^2.0.0"
-  },
-  "packageManager": "pnpm@9.15.4"
+  }
 }

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -16,5 +16,5 @@
     "prettier": "^3.3.3",
     "wrangler": "^3.71.0"
   },
-  "packageManager": "pnpm@9.15.4"
+  "packageManager": "pnpm@9.15.4+sha256.9bee59c7313a216722c079c1e22160dea7f88df4e0c3450b1d7b01b882336c6a"
 }


### PR DESCRIPTION
close #940 