### PR TITLE
fix: 勝者が決定できない場合にもMainMatchRepositoryをupdateする

### DIFF
--- a/packages/kcms/src/match/service/createRunResult.ts
+++ b/packages/kcms/src/match/service/createRunResult.ts
@@ -65,9 +65,10 @@ export class CreateRunResultService {
       const match = Option.unwrap(matchRes);
       try {
         match.appendRunResults(runResults);
+        await this.mainMatchRepository.update(match);
         const winnerRes = this.decideWinner(match);
         if (Option.isSome(winnerRes)) {
-          this.setMainWinner.handle(match.getID(), Option.unwrap(winnerRes));
+          await this.setMainWinner.handle(match.getID(), Option.unwrap(winnerRes));
         }
       } catch (e) {
         return Result.err(e as Error);


### PR DESCRIPTION
close #1191 

#1126 で誤って勝者が自動決定できる場合にしか`mainMathRepository.update`が呼ばれないようになっていたので、いかなる場合でも自動決定の前にこれを呼び出すようにした

### 気になること

- 勝者が自動決定できる場合は`setMainWinner.handle`の中でも`mainMathRepository.update`が呼ばれるのでクエリが2回走ることになる