### PR TITLE
feat: 試合ページ以外を試合表ページと同じレイアウトに統一

### DIFF
--- a/packages/kcmsf/src/pages/home.tsx
+++ b/packages/kcmsf/src/pages/home.tsx
@@ -3,7 +3,7 @@ import { RouterNavLink } from "../components/RouterNavLink";
 
 export const Home = () => {
   return (
-    <Stack gap="md">
+    <Stack w="fit-content" align="center" gap="md">
       <Title m="md">Home</Title>
       <Stack gap={0} w="15rem">
         <NavLink label="参加者" color="dark" variant="subtle" defaultOpened>

--- a/packages/kcmsf/src/pages/matchList.tsx
+++ b/packages/kcmsf/src/pages/matchList.tsx
@@ -97,8 +97,8 @@ export const MatchList = () => {
   );
 
   return (
-    <Stack justify="center" align="center" gap="md" w="fit-content">
-      <Title m="1rem">試合表</Title>
+    <Stack w="fit-content" align="center" gap="md">
+      <Title m="md">試合表</Title>
       <LabeledSegmentedControls>
         <MatchSegmentedControl
           matchType={matchType}

--- a/packages/kcmsf/src/pages/ranking.tsx
+++ b/packages/kcmsf/src/pages/ranking.tsx
@@ -103,8 +103,8 @@ export const Ranking = () => {
   useInterval(refetch, 10000, { active: isAutoReload });
 
   return (
-    <Flex direction="column" align="center" justify="center" gap="md">
-      <Title mt="md">ランキング</Title>
+    <Stack w="fit-content" align="center" gap="md">
+      <Title m="md">ランキング</Title>
       <LabeledSegmentedControls>
         <MatchSegmentedControl
           matchType={matchType}
@@ -181,7 +181,7 @@ export const Ranking = () => {
           />
         )}
       </Flex>
-    </Flex>
+    </Stack>
   );
 };
 

--- a/packages/kcmsf/src/pages/register.tsx
+++ b/packages/kcmsf/src/pages/register.tsx
@@ -59,7 +59,7 @@ export const Register = () => {
 
   return (
     <Stack w="fit-content" align="center" gap="md">
-      <Title m="md">参加者登録</Title>
+      <Title m="md">チーム登録</Title>
       <form onSubmit={submit}>
         <TextInput
           mt={"md"}

--- a/packages/kcmsf/src/pages/register.tsx
+++ b/packages/kcmsf/src/pages/register.tsx
@@ -1,4 +1,11 @@
-import { Box, Button, Group, SegmentedControl, TextInput } from "@mantine/core";
+import {
+  Button,
+  Group,
+  SegmentedControl,
+  Stack,
+  TextInput,
+  Title,
+} from "@mantine/core";
 import { notifications } from "@mantine/notifications";
 import { config, DepartmentType, RobotType } from "config";
 import { useState } from "react";
@@ -51,7 +58,8 @@ export const Register = () => {
   }
 
   return (
-    <Box maw={620} mx={"auto"}>
+    <Stack w="fit-content" align="center" gap="md">
+      <Title m="md">参加者登録</Title>
       <form onSubmit={submit}>
         <TextInput
           mt={"md"}
@@ -115,6 +123,6 @@ export const Register = () => {
           </Button>
         </Group>
       </form>
-    </Box>
+    </Stack>
   );
 };

--- a/packages/kcmsf/src/pages/registerBulk.tsx
+++ b/packages/kcmsf/src/pages/registerBulk.tsx
@@ -1,4 +1,13 @@
-import { Box, Button, Group, Paper, rem, Text, Title } from "@mantine/core";
+import {
+  Box,
+  Button,
+  Group,
+  Paper,
+  rem,
+  Stack,
+  Text,
+  Title,
+} from "@mantine/core";
 import { Dropzone } from "@mantine/dropzone";
 import { notifications } from "@mantine/notifications";
 import {
@@ -106,8 +115,8 @@ export const RegisterBulk = () => {
   };
 
   return (
-    <>
-      <Title>一括エントリー</Title>
+    <Stack w="fit-content" align="center" gap="md">
+      <Title m="md">一括エントリー</Title>
       {csvData ? (
         <>
           <p>この内容で登録します</p>
@@ -193,6 +202,6 @@ export const RegisterBulk = () => {
         </Paper>
       )}
       <CsvExample />
-    </>
+    </Stack>
   );
 };

--- a/packages/kcmsf/src/pages/result.tsx
+++ b/packages/kcmsf/src/pages/result.tsx
@@ -1,4 +1,4 @@
-import { Flex, Select, Table, Title } from "@mantine/core";
+import { Select, Stack, Table, Title } from "@mantine/core";
 import { DepartmentType, config } from "config";
 import { useMemo } from "react";
 import { useDepartmentTypeQuery } from "../hooks/useDepartmentTypeQuery";
@@ -38,7 +38,8 @@ export const Result = () => {
   );
 
   return (
-    <>
+    <Stack w="fit-content" align="center" gap="md">
+      <Title m="md">試合結果</Title>
       <Select
         label="部門"
         data={config.departments.map((element) => ({
@@ -49,12 +50,12 @@ export const Result = () => {
         defaultValue={config.departments[0].type}
         onChange={(value) => value && setDepartment(value as DepartmentType)}
       />
-      <Flex direction="column" gap={20}>
+      <Stack gap={20}>
         <Title order={3}>{config.department[department].name}</Title>
         <MainResultTable matches={mainMatches} teamNames={teamNames} />
         <PreResultTable matches={preMatches} />
-      </Flex>
-    </>
+      </Stack>
+    </Stack>
   );
 };
 

--- a/packages/kcmsf/src/pages/teams.tsx
+++ b/packages/kcmsf/src/pages/teams.tsx
@@ -4,6 +4,7 @@ import {
   Flex,
   Loader,
   Space,
+  Stack,
   Table,
   Text,
   Title,
@@ -166,9 +167,8 @@ export const Teams = () => {
   }, [setTeams, teamsRes]);
 
   return (
-    <Flex direction="column" align="center" justify="center">
+    <Stack w="fit-content" align="center" gap="md">
       <Title m="md">チーム一覧</Title>
-      <Space h={20} />
       {processedTeams ? (
         <>
           <Flex w="100%" justify="right">
@@ -176,7 +176,6 @@ export const Teams = () => {
               フィルターをリセット
             </Button>
           </Flex>
-          <Space h={10} />
           <TeamTable
             teams={processedTeams}
             sortState={sortState}
@@ -191,7 +190,7 @@ export const Teams = () => {
       ) : (
         <Loader m="xl" />
       )}
-    </Flex>
+    </Stack>
   );
 };
 

--- a/packages/kcmsf/src/pages/tournament.tsx
+++ b/packages/kcmsf/src/pages/tournament.tsx
@@ -18,7 +18,7 @@ export const Tournament = () => {
   const navigate = useNavigate();
 
   return (
-    <Stack gap="md" flex={1} justify="center" align="center">
+    <Stack w="fit-content" align="center" gap="md" flex={1}>
       <Title m="md">本戦トーナメント</Title>
       <LabeledSegmentedControls>
         <DepartmentSegmentedControl


### PR DESCRIPTION
close #1214

試合表・チーム一覧のページのレイアウトに統一してみました
トーナメントページで`flex: 1`が追加で必要になるのでコンポーネントにはしていません(したほうがいい？)