### PR TITLE
feat(WIP): WebSocket で 試合イベントを送受信する機能、および表示用の画面を追加

### DIFF
--- a/packages/kcms/src/main.ts
+++ b/packages/kcms/src/main.ts
@@ -6,6 +6,7 @@ MIT License.
 import { Context, Hono } from 'hono';
 import { env } from 'hono/adapter';
 import { basicAuth } from 'hono/basic-auth';
+import { websocket } from 'hono/bun';
 import { except } from 'hono/combine';
 import { deleteCookie, setSignedCookie } from 'hono/cookie';
 import { cors } from 'hono/cors';
@@ -15,6 +16,7 @@ import { secureHeaders } from 'hono/secure-headers';
 import { trimTrailingSlash } from 'hono/trailing-slash';
 import { z } from 'zod';
 import { matchHandler } from './match/main';
+import { matchWsHandler } from './matchWs/main';
 import { sponsorHandler } from './sponser/main';
 import { teamHandler } from './team/main.js';
 
@@ -135,9 +137,11 @@ app.get('/', (c) => c.json({ message: 'kcms is up' }));
 app.route('/', teamHandler);
 app.route('/', matchHandler);
 app.route('/', sponsorHandler);
+app.route('/', matchWsHandler);
 
 // ToDo: config packageのTS読み込み問題により、一時的にBunで直接TSを実行する形に変更した
 export default {
   port: 3000,
   fetch: app.fetch,
+  websocket,
 };

--- a/packages/kcms/src/matchWs/controller.ts
+++ b/packages/kcms/src/matchWs/controller.ts
@@ -1,0 +1,60 @@
+// FIXME: 雑実装
+
+import { Result } from '@mikuroxina/mini-fn';
+import { MainMatchID } from '../match/model/main';
+import { PreMatchID } from '../match/model/pre';
+import { GetMatchService } from '../match/service/get';
+
+type LivingMatch = {
+  id: string;
+  eventTarget: EventTarget;
+};
+
+export class MatchWebSocketController {
+  private readonly livingMatches: Map<string, LivingMatch>;
+
+  constructor(private readonly getMatch: GetMatchService) {
+    this.livingMatches = new Map();
+  }
+
+  async listenMatch(
+    matchId: PreMatchID | MainMatchID,
+    wsSend: (data: string) => void
+  ): Promise<Result.Result<Error, LivingMatch>> {
+    const matchRes = await this.getMatch.findByID(matchId);
+    if (Result.isErr(matchRes)) return matchRes;
+
+    const livingMatch: LivingMatch = this.livingMatches.get(matchId) ?? {
+      id: matchId,
+      eventTarget: new EventTarget(),
+    };
+    if (!this.livingMatches.has(matchId)) this.livingMatches.set(matchId, livingMatch);
+
+    livingMatch.eventTarget.addEventListener('update', (event) => {
+      if (!(event instanceof CustomEvent)) return;
+
+      wsSend(event.detail);
+    });
+
+    return Result.ok(livingMatch);
+  }
+
+  async updateMatchState(
+    matchId: PreMatchID | MainMatchID,
+    data: string
+  ): Promise<Result.Result<Error, LivingMatch>> {
+    const matchRes = await this.getMatch.findByID(matchId);
+    if (Result.isErr(matchRes)) return matchRes;
+
+    const livingMatch = this.livingMatches.get(matchId) ?? {
+      id: matchId,
+      state: {},
+      eventTarget: new EventTarget(),
+    };
+    if (!this.livingMatches.has(matchId)) this.livingMatches.set(matchId, livingMatch);
+
+    livingMatch.eventTarget.dispatchEvent(new CustomEvent('update', { detail: data }));
+
+    return Result.ok(livingMatch);
+  }
+}

--- a/packages/kcms/src/matchWs/main.ts
+++ b/packages/kcms/src/matchWs/main.ts
@@ -1,0 +1,49 @@
+// FIXME: 雑実装, API スキーマを書く, ドキュメント出力
+
+import { Hono } from 'hono';
+import { upgradeWebSocket } from 'hono/bun';
+import { prismaClient } from '../adaptor';
+import { PrismaMainMatchRepository } from '../match/adaptor/prisma/mainMatchRepository';
+import { PrismaPreMatchRepository } from '../match/adaptor/prisma/preMatchRepository';
+import { MainMatchID } from '../match/model/main';
+import { PreMatchID } from '../match/model/pre';
+import { GetMatchService } from '../match/service/get';
+import { MatchWebSocketController } from './controller';
+
+const preMatchRepository = new PrismaPreMatchRepository(prismaClient);
+const mainMatchRepository = new PrismaMainMatchRepository(prismaClient);
+
+const getMatchService = new GetMatchService(preMatchRepository, mainMatchRepository);
+
+const matchWsController = new MatchWebSocketController(getMatchService);
+
+export const matchWsHandler = new Hono();
+
+matchWsHandler.get(
+  '/match/:matchType/:matchId/ws/view',
+  upgradeWebSocket((c) => {
+    const { matchId } = c.req.param();
+
+    return {
+      onOpen: (_event, ws) => {
+        matchWsController.listenMatch(matchId as PreMatchID | MainMatchID, (data) => ws.send(data));
+      },
+    };
+  })
+);
+
+matchWsHandler.get(
+  '/match/:matchType/:matchId/ws/update',
+  upgradeWebSocket((c) => {
+    const { matchId } = c.req.param();
+
+    return {
+      onMessage: (event) => {
+        matchWsController.updateMatchState(
+          matchId as PreMatchID | MainMatchID,
+          event.data.toString()
+        );
+      },
+    };
+  })
+);

--- a/packages/kcmsf/src/components/match/PointControl.tsx
+++ b/packages/kcmsf/src/components/match/PointControl.tsx
@@ -11,6 +11,7 @@ interface Props {
   onChange: (value: Parameters<Rule["point"]>[0]) => void;
   children: React.ReactNode;
   disabled?: boolean;
+  unclickable?: boolean;
 }
 
 export const PointControl = (props: Props) => (
@@ -20,6 +21,7 @@ export const PointControl = (props: Props) => (
         value={props.team.point.state[props.rule.name]}
         color={props.color}
         onChange={(active) => {
+          if (props.unclickable) return;
           if (props.rule.type !== "single") return; // type narrowing
 
           props.team.point.state[props.rule.name] = active;
@@ -39,6 +41,7 @@ export const PointControl = (props: Props) => (
         color={props.color}
         validate={props.rule.validate}
         onChange={(count) => {
+          if (props.unclickable) return;
           if (props.rule.type !== "countable") return; // type narrowing
 
           props.team.point.state[props.rule.name] = count;

--- a/packages/kcmsf/src/components/match/PointControls.tsx
+++ b/packages/kcmsf/src/components/match/PointControls.tsx
@@ -10,6 +10,7 @@ export const PointControls = (props: {
   onChange: () => void;
   onGoal: (done: boolean) => void;
   disabled?: boolean;
+  unclickable?: boolean;
 }) => {
   return (
     <Flex direction="column" gap="xs">
@@ -29,6 +30,7 @@ export const PointControls = (props: {
               }}
               key={`${props.team.point.premiseState.side}-${rule.name}`}
               disabled={props.disabled}
+              unclickable={props.unclickable}
             >
               {rule.label}
               {rule.name === "goal" && props.team.goalTimeSeconds != null

--- a/packages/kcmsf/src/hooks/useForceReload.ts
+++ b/packages/kcmsf/src/hooks/useForceReload.ts
@@ -1,6 +1,5 @@
-import { useState } from "react";
+import { useReducer } from "react";
 
 export const useForceReload = () => {
-  const setID = useState(0)[1];
-  return () => setID((prev) => prev + 1);
+  return useReducer((prev) => prev + 1, 0)[1];
 };

--- a/packages/kcmsf/src/hooks/useMatchEventListener.ts
+++ b/packages/kcmsf/src/hooks/useMatchEventListener.ts
@@ -1,0 +1,29 @@
+import { MatchType } from "config";
+import { useEffect, useRef } from "react";
+import { MatchEvent } from "../types/matchWs";
+import { useWebSocket } from "./useWebSocket";
+
+export const useMatchEventListener = (
+  matchType: MatchType | undefined,
+  matchId: string | undefined,
+  onMatchEvent: (event: MatchEvent) => void
+) => {
+  if (matchType == null || matchId == null) throw new Error("Not implemented");
+
+  const onMatchEventRef = useRef(onMatchEvent);
+
+  useEffect(() => {
+    onMatchEventRef.current = onMatchEvent;
+  }, [onMatchEvent]);
+
+  useWebSocket(
+    `${import.meta.env.VITE_API_URL}/match/${matchType}/${matchId}/ws/view`,
+    {
+      onMessage: (event) => {
+        // FIXME: バリデーション
+        const matchEvent = JSON.parse(event.data) as MatchEvent;
+        onMatchEventRef.current(matchEvent);
+      },
+    }
+  );
+};

--- a/packages/kcmsf/src/hooks/useMatchEventSender.ts
+++ b/packages/kcmsf/src/hooks/useMatchEventSender.ts
@@ -1,0 +1,47 @@
+import { MatchType } from "config";
+import { useCallback } from "react";
+import {
+  MatchEventMatchEnded,
+  MatchEventTeamUpdated,
+  MatchEventTimerUpdated,
+} from "../types/matchWs";
+import { useWebSocket } from "./useWebSocket";
+
+export const useMatchEventSender = (
+  matchType: MatchType | undefined,
+  matchId: string | undefined
+) => {
+  const wsRef = useWebSocket(
+    `${import.meta.env.VITE_API_URL}/match/${matchType}/${matchId}/ws/update`,
+    {}
+  );
+
+  const sendTeamUpdated = useCallback(
+    (data: Omit<MatchEventTeamUpdated, "type">) => {
+      const event: MatchEventTeamUpdated = {
+        type: "TEAM_UPDATED",
+        ...data,
+      };
+      wsRef.current?.send(JSON.stringify(event));
+    },
+    []
+  );
+  const sendTimerUpdated = useCallback(
+    (data: Omit<MatchEventTimerUpdated, "type">) => {
+      const event: MatchEventTimerUpdated = {
+        type: "TIMER_UPDATED",
+        ...data,
+      };
+      wsRef.current?.send(JSON.stringify(event));
+    },
+    []
+  );
+  const sendMatchEnded = useCallback(() => {
+    const event: MatchEventMatchEnded = {
+      type: "MATCH_ENDED",
+    };
+    wsRef.current?.send(JSON.stringify(event));
+  }, []);
+
+  return { sendTeamUpdated, sendTimerUpdated, sendMatchEnded };
+};

--- a/packages/kcmsf/src/hooks/useMatchTimer.ts
+++ b/packages/kcmsf/src/hooks/useMatchTimer.ts
@@ -3,7 +3,8 @@ import { useCallback, useState } from "react";
 import { useTimer } from "react-timer-hook";
 import { expiryTimestamp } from "../utils/time";
 
-type TimerState = "initial" | "counting" | "finished";
+// FIXME: 型情報を適切な場所に置く
+export type TimerState = "initial" | "counting" | "finished";
 
 export const useMatchTimer = (
   matchType: MatchType

--- a/packages/kcmsf/src/hooks/useWebSocket.ts
+++ b/packages/kcmsf/src/hooks/useWebSocket.ts
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from "react";
+
+export const useWebSocket = (
+  url: string,
+  listener: {
+    onOpen?: (event: Event) => any;
+    onMessage?: (event: MessageEvent) => any;
+    onError?: (event: Event) => any;
+    onClose?: (event: CloseEvent) => any;
+  },
+  protocols?: string
+) => {
+  const wsRef = useRef<WebSocket>(undefined);
+
+  useEffect(() => {
+    const { onOpen, onMessage, onError, onClose } = listener;
+
+    wsRef.current = new WebSocket(url, protocols);
+
+    if (onOpen) wsRef.current.addEventListener("open", onOpen);
+    if (onMessage) wsRef.current.addEventListener("message", onMessage);
+    if (onError) wsRef.current.addEventListener("error", onError);
+    if (onClose) wsRef.current.addEventListener("close", onClose);
+
+    return () => {
+      if (onOpen) wsRef.current?.removeEventListener("open", onOpen);
+      if (onMessage) wsRef.current?.removeEventListener("message", onMessage);
+      if (onError) wsRef.current?.removeEventListener("error", onError);
+      if (onClose) wsRef.current?.removeEventListener("close", onClose);
+
+      wsRef.current?.close();
+    };
+  }, []);
+
+  return wsRef;
+};

--- a/packages/kcmsf/src/pages/match.tsx
+++ b/packages/kcmsf/src/pages/match.tsx
@@ -44,7 +44,7 @@ export const Match = () => {
       (side == "left" ? leftDisplayedTeam : rightDisplayedTeam).judge.reset();
       forceReload();
     },
-    [matchJudge, forceReload]
+    [matchJudge, forceReload, leftDisplayedTeam, rightDisplayedTeam]
   );
   return (
     <Flex

--- a/packages/kcmsf/src/pages/matchView.tsx
+++ b/packages/kcmsf/src/pages/matchView.tsx
@@ -1,0 +1,155 @@
+import { Button, Divider, Flex, Text } from "@mantine/core";
+import { IconSwitchHorizontal } from "@tabler/icons-react";
+import { config, MatchType } from "config";
+import { useCallback, useMemo, useState } from "react";
+import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { MatchNameCard } from "../components/match/MatchNameCard";
+import { MatchPointCard } from "../components/match/MatchPointCard";
+import { PointControls } from "../components/match/PointControls";
+import { useDisplayedTeam } from "../hooks/useDisplayedTeam";
+import { useForceReload } from "../hooks/useForceReload";
+import { useJudge } from "../hooks/useJudge";
+import { useMatchEventListener } from "../hooks/useMatchEventListener";
+import { useMatchInfo } from "../hooks/useMatchInfo";
+import { TimerState } from "../hooks/useMatchTimer";
+import { MatchEvent } from "../types/matchWs";
+import { getMatchStatus } from "../utils/matchStatus";
+import { parseSeconds } from "../utils/time";
+
+export const MatchView = () => {
+  const { id, matchType } = useParams<{ id: string; matchType: MatchType }>();
+  const isExhibition = !id || !matchType;
+  const { match, matchInfo } = useMatchInfo(id, matchType);
+  const matchJudge = useJudge(matchInfo);
+  const forceReload = useForceReload();
+  const navigate = useNavigate();
+  const matchStatus = useMemo(() => match && getMatchStatus(match), [match]);
+
+  const {
+    teams: [leftDisplayedTeam, rightDisplayedTeam],
+    displayedCourseName: [leftDisplayedCourseName, rightDisplayedCourseName],
+    flip,
+  } = useDisplayedTeam(matchInfo, matchJudge);
+
+  const [isRunning, setIsRunning] = useState(false);
+  const [timerState, setTimerState] = useState<TimerState>("initial");
+  const [totalSeconds, setTotalSeconds] = useState<number>(
+    config.match[matchType ?? "pre"].limitSeconds
+  );
+
+  const onMatchEvent = useCallback(
+    (event: MatchEvent) => {
+      switch (event.type) {
+        case "TIMER_UPDATED":
+          const { isRunning, state, totalSeconds } = event;
+          if (isRunning != null) setIsRunning(isRunning);
+          if (state != null) setTimerState(state);
+          if (totalSeconds != null) setTotalSeconds(totalSeconds);
+          break;
+        case "TEAM_UPDATED":
+          const { side, pointState, goalTimeSeconds } = event;
+          matchJudge.team(side).point.reset(pointState);
+          matchJudge.goal(side, goalTimeSeconds);
+          forceReload();
+          break;
+        case "MATCH_ENDED":
+          navigate(`/match/${matchType}/${id}`);
+          break;
+        default:
+          throw new Error("Unknown match event:", { cause: event });
+      }
+    },
+    [matchJudge]
+  );
+
+  useMatchEventListener(matchType, id, onMatchEvent);
+
+  if (matchStatus === "end")
+    return <Navigate to={`/match/${matchType}/${id}`} replace />;
+
+  return (
+    <Flex
+      h="100%"
+      direction="column"
+      gap="md"
+      align="center"
+      justify="center"
+      w="100%"
+    >
+      <>
+        {match && matchInfo && (
+          <MatchNameCard
+            matchType={matchInfo.matchType}
+            matchCode={match.matchCode}
+            rightTeamName={rightDisplayedTeam.info?.teamName}
+            leftTeamName={leftDisplayedTeam.info?.teamName}
+            centerSection={
+              <>
+                {match.matchType === "main" &&
+                  `${match.runResults.length == 0 ? 1 : 2}試合目`}
+                <Button
+                  onClick={flip}
+                  variant="subtle"
+                  size="compact-sm"
+                  color="violet"
+                  leftSection={<IconSwitchHorizontal size={14} />}
+                >
+                  左右を反転
+                </Button>
+              </>
+            }
+            leftTeamCourseName={leftDisplayedCourseName}
+            rightTeamCourseName={rightDisplayedCourseName}
+          />
+        )}
+        <Button
+          w="100%"
+          h="auto"
+          p="xs"
+          variant="filled"
+          color={
+            timerState == "finished" ? "pink" : isRunning ? "teal" : "gray"
+          }
+        >
+          <Text size="5rem">{parseSeconds(totalSeconds)}</Text>
+        </Button>
+        <MatchPointCard
+          rightTeamPoint={
+            isExhibition || rightDisplayedTeam.info
+              ? rightDisplayedTeam.judge.point.point()
+              : 0
+          }
+          leftTeamPoint={
+            isExhibition || leftDisplayedTeam.info
+              ? leftDisplayedTeam.judge.point.point()
+              : 0
+          }
+        />
+
+        <Divider w="100%" />
+
+        <Flex direction="row" gap="2rem" align="center" justify="center">
+          <PointControls
+            color="blue"
+            team={leftDisplayedTeam.judge}
+            onChange={() => {}}
+            onGoal={() => {}}
+            disabled={!isExhibition && !leftDisplayedTeam.info}
+            unclickable
+          />
+
+          <Divider orientation="vertical" />
+
+          <PointControls
+            color="red"
+            team={rightDisplayedTeam.judge}
+            onChange={() => {}}
+            onGoal={() => {}}
+            disabled={!isExhibition && !rightDisplayedTeam.info}
+            unclickable
+          />
+        </Flex>
+      </>
+    </Flex>
+  );
+};

--- a/packages/kcmsf/src/routes/router.tsx
+++ b/packages/kcmsf/src/routes/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from "react-router-dom";
 import { Home } from "../pages/home.tsx";
 import { Match } from "../pages/match.tsx";
 import { MatchList } from "../pages/matchList.tsx";
+import { MatchView } from "../pages/matchView.tsx";
 import { Ranking } from "../pages/ranking.tsx";
 import { Register } from "../pages/register.tsx";
 import { RegisterBulk } from "../pages/registerBulk.tsx";
@@ -43,7 +44,16 @@ export const router = createBrowserRouter(
         },
         {
           path: "match/:matchType/:id",
-          element: <Match />,
+          children: [
+            {
+              index: true,
+              element: <Match />,
+            },
+            {
+              path: "view",
+              element: <MatchView />,
+            },
+          ],
         },
         {
           path: "matchlist",

--- a/packages/kcmsf/src/types/matchWs.ts
+++ b/packages/kcmsf/src/types/matchWs.ts
@@ -1,0 +1,29 @@
+import { PointState } from "config";
+import { Side } from "config/src/types/matchInfo";
+import { TimerState } from "../hooks/useMatchTimer";
+
+export type MatchEventType = "TEAM_UPDATED" | "TIMER_UPDATED" | "MATCH_ENDED";
+
+type _RestrictMatchEvent<T extends { type: MatchEventType }> = T;
+
+export type MatchEventTeamUpdated = _RestrictMatchEvent<{
+  type: "TEAM_UPDATED";
+  side: Side;
+  pointState: PointState;
+  goalTimeSeconds: number | undefined;
+}>;
+
+export type MatchEventTimerUpdated = _RestrictMatchEvent<{
+  type: "TIMER_UPDATED";
+  totalSeconds?: number;
+  isRunning?: boolean;
+  state?: TimerState;
+}>;
+
+export type MatchEventMatchEnded = _RestrictMatchEvent<{
+  type: "MATCH_ENDED";
+}>;
+
+export type MatchEvent = _RestrictMatchEvent<
+  MatchEventTeamUpdated | MatchEventTimerUpdated | MatchEventMatchEnded
+>;

--- a/packages/kcmsf/src/utils/match/judge.ts
+++ b/packages/kcmsf/src/utils/match/judge.ts
@@ -54,4 +54,12 @@ export class Judge {
   goalRightTeam(goalTimeSec: number | undefined) {
     this._setGoalTimeSecRight(goalTimeSec);
   }
+
+  goal(side: keyof MatchInfo["teams"], goalTimeSec: number | undefined) {
+    if (side === "left") {
+      this.goalLeftTeam(goalTimeSec);
+    } else {
+      this.goalRightTeam(goalTimeSec);
+    }
+  }
 }

--- a/packages/kcmsf/src/utils/match/point.ts
+++ b/packages/kcmsf/src/utils/match/point.ts
@@ -1,4 +1,4 @@
-import { config, PointState, PremiseState } from "config";
+import { config, initialPointState, PointState, PremiseState } from "config";
 
 export class Point {
   private readonly _state: PointState;
@@ -27,9 +27,9 @@ export class Point {
       .reduce((sum, point) => (sum += point), 0);
   }
 
-  public reset(): void {
+  public reset(state: PointState = initialPointState): void {
     config.rules.forEach((rule) => {
-      this._state[rule.name] = rule.initial as never;
+      this._state[rule.name] = state[rule.name] as never;
     });
   }
 }


### PR DESCRIPTION
試合ページのURL末尾に `/view` を付けたものが表示用画面になります
ローカルデバッグしかしていません、動作確認お願いします　できれば `wss://` 環境で試してもらえると助かります